### PR TITLE
fix: compose prerequisite tasks in router and dashboard

### DIFF
--- a/lib/mix/tasks/phx/install/dashboard.ex
+++ b/lib/mix/tasks/phx/install/dashboard.ex
@@ -29,7 +29,8 @@ defmodule Mix.Tasks.Phx.Install.Dashboard do
     %Igniter.Mix.Task.Info{
       group: :phoenix,
       example: "mix phx.install.dashboard",
-      adds_deps: [{:phoenix_live_dashboard, "~> 0.8"}]
+      adds_deps: [{:phoenix_live_dashboard, "~> 0.8"}],
+      composes: ["phx.install.endpoint", "phx.install.live"]
     }
   end
 
@@ -43,6 +44,8 @@ defmodule Mix.Tasks.Phx.Install.Dashboard do
     igniter
     |> Igniter.Project.Deps.add_dep({:phoenix, "~> 1.7"})
     |> Igniter.Project.Deps.add_dep({:phoenix_live_dashboard, "~> 0.8"})
+    |> Igniter.compose_task("phx.install.endpoint")
+    |> Igniter.compose_task("phx.install.live")
     |> add_dashboard_route(app_name, router_module, telemetry_module)
   end
 

--- a/lib/mix/tasks/phx/install/router.ex
+++ b/lib/mix/tasks/phx/install/router.ex
@@ -22,7 +22,8 @@ defmodule Mix.Tasks.Phx.Install.Router do
   def info(_argv, _composing_task) do
     %Igniter.Mix.Task.Info{
       group: :phoenix,
-      example: "mix phx.install.router"
+      example: "mix phx.install.router",
+      composes: ["phx.install.core"]
     }
   end
 
@@ -33,6 +34,7 @@ defmodule Mix.Tasks.Phx.Install.Router do
 
     igniter
     |> Igniter.Project.Deps.add_dep({:phoenix, "~> 1.7"})
+    |> Igniter.compose_task("phx.install.core")
     |> create_router(web_module)
     |> create_error_json(web_module)
     |> create_conn_case(web_module, endpoint_module)

--- a/test/mix/tasks/phx/install/router_test.exs
+++ b/test/mix/tasks/phx/install/router_test.exs
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Phx.Install.RouterTest do
     test "creates error_json module" do
       test_project()
       |> Igniter.compose_task("phx.install.router")
-      |> assert_creates("lib/test_web/error_json.ex")
+      |> assert_creates("lib/test_web/controllers/error_json.ex")
     end
 
     test "error_json has correct structure" do
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.Phx.Install.RouterTest do
         |> Igniter.compose_task("phx.install.router")
         |> apply_igniter!()
 
-      source = Rewrite.source!(igniter.rewrite, "lib/test_web/error_json.ex")
+      source = Rewrite.source!(igniter.rewrite, "lib/test_web/controllers/error_json.ex")
       content = Rewrite.Source.get(source, :content)
 
       assert content =~ "defmodule TestWeb.ErrorJSON"
@@ -77,7 +77,7 @@ defmodule Mix.Tasks.Phx.Install.RouterTest do
         |> apply_igniter!()
 
       assert igniter.rewrite.sources["lib/my_app_web/router.ex"]
-      assert igniter.rewrite.sources["lib/my_app_web/error_json.ex"]
+      assert igniter.rewrite.sources["lib/my_app_web/controllers/error_json.ex"]
       assert igniter.rewrite.sources["lib/my_app_web/conn_case.ex"]
 
       router_content =


### PR DESCRIPTION
## Summary

- `phx.install.router` now composes `phx.install.core` so the application module and supervision tree are set up when run standalone
- `phx.install.dashboard` now composes `phx.install.endpoint` and `phx.install.live` so all prerequisite infrastructure is in place when run standalone
- Updated router tests to reflect that the Phoenix extension (registered by core) places controllers under `controllers/`

Closes #4

## Test plan

- [x] All 155 tests pass
- [x] Verify `mix phx.install.router` standalone creates application.ex with supervision children
- [x] Verify `mix phx.install.dashboard` standalone creates full Phoenix + LiveView infrastructure