### PR TITLE
Composable asset pipeline with pluggable bundler support

### DIFF
--- a/lib/mix/tasks/phx/install/assets.ex
+++ b/lib/mix/tasks/phx/install/assets.ex
@@ -1,27 +1,41 @@
 defmodule Mix.Tasks.Phx.Install.Assets do
-  @shortdoc "Sets up the asset pipeline with esbuild and Tailwind CSS"
+  @shortdoc "Sets up the asset pipeline"
   @moduledoc """
-  Sets up the asset build pipeline with esbuild and Tailwind CSS.
+  Sets up the asset build pipeline for a Phoenix application.
 
-  This task sets up:
-  - `esbuild` and `tailwind` dependencies
-  - `assets/js/app.js` - JavaScript entry point
-  - `assets/css/app.css` - Tailwind CSS entry point
-  - `assets/vendor/topbar.js` - Progress indicator for LiveView
-  - `priv/static/robots.txt` - Robots exclusion file
-  - `priv/static/favicon.ico` - Default favicon
-  - esbuild and tailwind configuration in config.exs
-  - Asset watchers in dev.exs
-  - Asset aliases in mix.exs (assets.setup, assets.build, assets.deploy)
+  This is an orchestrator that composes individual asset subtasks based on
+  the chosen bundler and options.
 
   ## Usage
 
       mix phx.install.assets
+      mix phx.install.assets --bundler esbuild --lang ts
+      mix phx.install.assets --no-tailwind
+      mix phx.install.assets --bundler none
 
   ## Options
 
-  - `--no-esbuild` - Skip JavaScript bundling with esbuild
-  - `--no-tailwind` - Skip Tailwind CSS
+  - `--bundler` - JavaScript bundler to use: "esbuild" (default) or "none" to skip
+  - `--lang` - Language for the JS entry point: "js" (default) or "ts"
+  - `--tailwind` / `--no-tailwind` - Include Tailwind CSS (default: true)
+
+  ## What Gets Installed
+
+  Always installed:
+  - `phx.install.assets.static` - robots.txt and favicon
+  - `phx.install.assets.live_reload` - live reload configuration for dev
+
+  Based on `--bundler`:
+  - `phx.install.assets.esbuild` - esbuild + vendored topbar
+
+  Optional:
+  - `phx.install.assets.tailwind` - Tailwind CSS (runner varies by bundler)
+
+  ## Extensibility
+
+  To add support for a new bundler, implement two tasks:
+  - `phx.install.assets.<bundler_name>` - JS bundling setup
+  - `phx.install.assets.tailwind.<bundler_name>` - Tailwind CSS runner for that bundler
 
   This task is typically called by `mix phx.install` rather than directly.
   """
@@ -29,511 +43,101 @@ defmodule Mix.Tasks.Phx.Install.Assets do
 
   @impl Igniter.Mix.Task
   def info(argv, _composing_task) do
-    {parsed, _, _} = OptionParser.parse(argv, strict: [esbuild: :boolean, tailwind: :boolean])
-    esbuild? = Keyword.get(parsed, :esbuild, true)
+    {parsed, _, _} =
+      OptionParser.parse(argv,
+        strict: [bundler: :string, lang: :string, tailwind: :boolean]
+      )
+
+    bundler = Keyword.get(parsed, :bundler, "esbuild")
     tailwind? = Keyword.get(parsed, :tailwind, true)
 
-    deps =
-      if(esbuild?, do: [{:esbuild, "~> 0.10"}], else: []) ++
-        if(tailwind?, do: [{:tailwind, "~> 0.3"}], else: [])
+    bundler_tasks = if bundler == "none", do: [], else: ["phx.install.assets.#{bundler}"]
+    tailwind_tasks = if tailwind?, do: ["phx.install.assets.tailwind"], else: []
 
     %Igniter.Mix.Task.Info{
       group: :phoenix,
       example: "mix phx.install.assets",
-      adds_deps: deps,
-      schema: [
-        esbuild: :boolean,
-        tailwind: :boolean
-      ],
-      defaults: [
-        esbuild: true,
-        tailwind: true
-      ]
+      schema: [bundler: :string, lang: :string, tailwind: :boolean],
+      defaults: [bundler: "esbuild", lang: "js", tailwind: true],
+      composes:
+        [
+          "phx.install.assets.static",
+          "phx.install.assets.live_reload"
+        ] ++ bundler_tasks ++ tailwind_tasks
     }
   end
 
   @impl Igniter.Mix.Task
   def igniter(igniter) do
     app_name = Igniter.Project.Application.app_name(igniter)
-    web_module = Igniter.Libs.Phoenix.web_module(igniter)
-    endpoint_module = Module.concat(web_module, Endpoint)
 
     opts = igniter.args.options
-    esbuild? = opts[:esbuild]
-    tailwind? = opts[:tailwind]
+    bundler = opts[:bundler] || "esbuild"
+    lang = opts[:lang] || "js"
+    tailwind? = opts[:tailwind] != false
 
     igniter
-    |> maybe_add_dep({:esbuild, "~> 0.10"}, esbuild?)
-    |> maybe_add_dep({:tailwind, "~> 0.3"}, tailwind?)
-    |> add_runtime_dep_option(:esbuild, esbuild?)
-    |> add_runtime_dep_option(:tailwind, tailwind?)
-    |> create_app_js(web_module, esbuild?)
-    |> create_app_css(web_module, tailwind?)
-    |> create_topbar_js(esbuild?)
-    |> create_robots_txt()
-    |> create_favicon()
-    |> configure_esbuild(app_name, esbuild?)
-    |> configure_tailwind(app_name, tailwind?)
-    |> configure_watchers(app_name, endpoint_module, esbuild?, tailwind?)
-    |> configure_live_reload(app_name, endpoint_module)
-    |> add_asset_aliases(app_name, esbuild?, tailwind?)
+    |> Igniter.compose_task("phx.install.assets.static")
+    |> Igniter.compose_task("phx.install.assets.live_reload")
+    |> maybe_compose_bundler(bundler, lang, tailwind?)
+    |> maybe_compose_tailwind(tailwind?, bundler)
+    |> maybe_add_aliases(app_name, bundler, tailwind?)
+    |> update_setup_alias()
   end
 
-  defp add_runtime_dep_option(igniter, dep, true) do
-    Igniter.Project.Deps.set_dep_option(
+  defp maybe_compose_bundler(igniter, "none", _lang, _tailwind?), do: igniter
+
+  defp maybe_compose_bundler(igniter, bundler, lang, tailwind?) do
+    Igniter.compose_task(
       igniter,
-      dep,
-      :runtime,
-      Sourceror.parse_string!("Mix.env() == :dev")
+      "phx.install.assets.#{bundler}",
+      bundler_args(lang, tailwind?)
     )
   end
 
-  defp add_runtime_dep_option(igniter, _dep, false), do: igniter
-
-  defp maybe_add_dep(igniter, dep, true),
-    do: Igniter.Project.Deps.add_dep(igniter, dep, on_exists: :skip)
-
-  defp maybe_add_dep(igniter, _dep, false), do: igniter
-
-  defp create_app_js(igniter, _web_module, true) do
-    content = """
-    // If you want to use Phoenix channels, run `mix help phx.gen.channel`
-    // to get started and then uncomment the line below.
-    // import "./user_socket.js"
-
-    // You can include dependencies in two ways.
-    //
-    // The simplest option is to put them in assets/vendor and
-    // import them using relative paths:
-    //
-    //     import "../vendor/some-package.js"
-    //
-    // Alternatively, you can `npm install some-package --prefix assets` and import
-    // them using a path starting with the package name:
-    //
-    //     import "some-package"
-    //
-
-    // Include phoenix_html to handle method=PUT/DELETE in forms and buttons.
-    import "phoenix_html"
-    // Establish Phoenix Socket and LiveView configuration.
-    import {Socket} from "phoenix"
-    import {LiveSocket} from "phoenix_live_view"
-    import topbar from "../vendor/topbar"
-
-    const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
-    const liveSocket = new LiveSocket("/live", Socket, {
-      longPollFallbackMs: 2500,
-      params: {_csrf_token: csrfToken}
-    })
-
-    // Show progress bar on live navigation and form submits
-    topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})
-    window.addEventListener("phx:page-loading-start", _info => topbar.show(300))
-    window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
-
-    // connect if there are any LiveViews on the page
-    liveSocket.connect()
-
-    // expose liveSocket on window for web console debug logs and latency simulation:
-    // >> liveSocket.enableDebug()
-    // >> liveSocket.enableLatencySim(1000)  // enabled for duration of browser session
-    // >> liveSocket.disableLatencySim()
-    window.liveSocket = liveSocket
-
-    // The lines below enable quality of life phoenix_live_reload
-    // development features:
-    //
-    //     1. stream server logs to the browser console
-    //     2. click on elements to jump to their definitions in your code editor
-    //
-    if (process.env.NODE_ENV === "development") {
-      window.addEventListener("phx:live_reload:attached", ({detail: reloader}) => {
-        // Enable server log streaming to client.
-        // Disable with reloader.disableServerLogs()
-        reloader.enableServerLogs()
-
-        // Open configured PLUG_EDITOR at file:line of the clicked element's HEEx component
-        //
-        //   * click with "c" key pressed to open at caller location
-        //   * click with "d" key pressed to open at function component definition location
-        let keyDown
-        window.addEventListener("keydown", e => keyDown = e.key)
-        window.addEventListener("keyup", _e => keyDown = null)
-        window.addEventListener("click", e => {
-          if(keyDown === "c"){
-            e.preventDefault()
-            e.stopImmediatePropagation()
-            reloader.openEditorAtCaller(e.target)
-          } else if(keyDown === "d"){
-            e.preventDefault()
-            e.stopImmediatePropagation()
-            reloader.openEditorAtDef(e.target)
-          }
-        }, true)
-
-        window.liveReloader = reloader
-      })
-    }
-    """
-
-    Igniter.create_new_file(igniter, "assets/js/app.js", content, on_exists: :skip)
+  defp bundler_args(lang, tailwind?) do
+    ["--lang", lang] ++
+      if(tailwind?, do: [], else: ["--no-tailwind"])
   end
 
-  defp create_app_js(igniter, _web_module, false), do: igniter
+  defp maybe_compose_tailwind(igniter, false, _bundler), do: igniter
 
-  defp create_app_css(igniter, web_module, true) do
-    lib_web_name =
-      web_module
-      |> Module.split()
-      |> List.last()
-      |> Macro.underscore()
-
-    content = """
-    /* See the Tailwind configuration guide for advanced usage
-       https://tailwindcss.com/docs/configuration */
-
-    @import "tailwindcss";
-    @source "../js";
-    @source "../../lib/#{lib_web_name}";
-
-    /* Add variants based on LiveView classes */
-    @custom-variant phx-click-loading (.phx-click-loading&, .phx-click-loading &);
-    @custom-variant phx-submit-loading (.phx-submit-loading&, .phx-submit-loading &);
-    @custom-variant phx-change-loading (.phx-change-loading&, .phx-change-loading &);
-
-    /* Make LiveView wrapper divs transparent for layout */
-    [data-phx-session], [data-phx-teleported-src] { display: contents }
-
-    /* This file is for your main application CSS */
-    """
-
-    Igniter.create_new_file(igniter, "assets/css/app.css", content, on_exists: :skip)
+  defp maybe_compose_tailwind(igniter, _tailwind?, "none") do
+    Igniter.compose_task(igniter, "phx.install.assets.tailwind", ["--bundler", "esbuild"])
   end
 
-  defp create_app_css(igniter, _web_module, false), do: igniter
-
-  defp create_topbar_js(igniter, true) do
-    content = """
-    /**
-     * @license MIT
-     * topbar 3.0.0
-     * http://buunguyen.github.io/topbar
-     * Copyright (c) 2024 Buu Nguyen
-     */
-    (function (window, document) {
-      "use strict";
-
-      var canvas,
-        currentProgress,
-        showing,
-        progressTimerId = null,
-        fadeTimerId = null,
-        delayTimerId = null,
-        addEvent = function (elem, type, handler) {
-          if (elem.addEventListener) elem.addEventListener(type, handler, false);
-          else if (elem.attachEvent) elem.attachEvent("on" + type, handler);
-          else elem["on" + type] = handler;
-        },
-        options = {
-          autoRun: true,
-          barThickness: 3,
-          barColors: {
-            0: "rgba(26,  188, 156, .9)",
-            ".25": "rgba(52,  152, 219, .9)",
-            ".50": "rgba(241, 196, 15,  .9)",
-            ".75": "rgba(230, 126, 34,  .9)",
-            "1.0": "rgba(211, 84,  0,   .9)",
-          },
-          shadowBlur: 10,
-          shadowColor: "rgba(0,   0,   0,   .6)",
-          className: null,
-        },
-        repaint = function () {
-          canvas.width = window.innerWidth;
-          canvas.height = options.barThickness * 5; // need space for shadow
-
-          var ctx = canvas.getContext("2d");
-          ctx.shadowBlur = options.shadowBlur;
-          ctx.shadowColor = options.shadowColor;
-
-          var lineGradient = ctx.createLinearGradient(0, 0, canvas.width, 0);
-          for (var stop in options.barColors)
-            lineGradient.addColorStop(stop, options.barColors[stop]);
-          ctx.lineWidth = options.barThickness;
-          ctx.beginPath();
-          ctx.moveTo(0, options.barThickness / 2);
-          ctx.lineTo(
-            Math.ceil(currentProgress * canvas.width),
-            options.barThickness / 2
-          );
-          ctx.strokeStyle = lineGradient;
-          ctx.stroke();
-        },
-        createCanvas = function () {
-          canvas = document.createElement("canvas");
-          var style = canvas.style;
-          style.position = "fixed";
-          style.top = style.left = style.right = style.margin = style.padding = 0;
-          style.zIndex = 100001;
-          style.display = "none";
-          if (options.className) canvas.classList.add(options.className);
-          addEvent(window, "resize", repaint);
-        },
-        topbar = {
-          config: function (opts) {
-            for (var key in opts)
-              if (options.hasOwnProperty(key)) options[key] = opts[key];
-          },
-          show: function (delay) {
-            if (showing) return;
-            if (delay) {
-              if (delayTimerId) return;
-              delayTimerId = setTimeout(() => topbar.show(), delay);
-            } else {
-              showing = true;
-              if (fadeTimerId !== null) window.cancelAnimationFrame(fadeTimerId);
-              if (!canvas) createCanvas();
-              if (!canvas.parentElement) document.body.appendChild(canvas);
-              canvas.style.opacity = 1;
-              canvas.style.display = "block";
-              topbar.progress(0);
-              if (options.autoRun) {
-                (function loop() {
-                  progressTimerId = window.requestAnimationFrame(loop);
-                  topbar.progress(
-                    "+" + 0.05 * Math.pow(1 - Math.sqrt(currentProgress), 2)
-                  );
-                })();
-              }
-            }
-          },
-          progress: function (to) {
-            if (typeof to === "undefined") return currentProgress;
-            if (typeof to === "string") {
-              to =
-                (to.indexOf("+") >= 0 || to.indexOf("-") >= 0
-                  ? currentProgress
-                  : 0) + parseFloat(to);
-            }
-            currentProgress = to > 1 ? 1 : to;
-            repaint();
-            return currentProgress;
-          },
-          hide: function () {
-            clearTimeout(delayTimerId);
-            delayTimerId = null;
-            if (!showing) return;
-            showing = false;
-            if (progressTimerId != null) {
-              window.cancelAnimationFrame(progressTimerId);
-              progressTimerId = null;
-            }
-            (function loop() {
-              if (topbar.progress("+.1") >= 1) {
-                canvas.style.opacity -= 0.05;
-                if (canvas.style.opacity <= 0.05) {
-                  canvas.style.display = "none";
-                  fadeTimerId = null;
-                  return;
-                }
-              }
-              fadeTimerId = window.requestAnimationFrame(loop);
-            })();
-          },
-        };
-
-      if (typeof module === "object" && typeof module.exports === "object") {
-        module.exports = topbar;
-      } else if (typeof define === "function" && define.amd) {
-        define(function () {
-          return topbar;
-        });
-      } else {
-        this.topbar = topbar;
-      }
-    }.call(this, window, document));
-    """
-
-    Igniter.create_new_file(igniter, "assets/vendor/topbar.js", content, on_exists: :skip)
+  defp maybe_compose_tailwind(igniter, _tailwind?, bundler) do
+    Igniter.compose_task(igniter, "phx.install.assets.tailwind", ["--bundler", bundler])
   end
 
-  defp create_topbar_js(igniter, false), do: igniter
+  defp maybe_add_aliases(igniter, _app_name, "none", _tailwind?), do: igniter
 
-  defp create_robots_txt(igniter) do
-    content = """
-    # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-    #
-    # To ban all spiders from the entire site uncomment the next two lines:
-    # User-agent: *
-    # Disallow: /
-    """
+  defp maybe_add_aliases(igniter, app_name, "esbuild", tailwind?) do
+    setup_tasks =
+      ["esbuild.install --if-missing"] ++
+        if(tailwind?, do: ["tailwind.install --if-missing"], else: [])
 
-    Igniter.create_new_file(igniter, "priv/static/robots.txt", content, on_exists: :skip)
-  end
+    build_tasks =
+      ["compile", "esbuild #{app_name}"] ++
+        if(tailwind?, do: ["tailwind #{app_name}"], else: [])
 
-  defp create_favicon(igniter) do
-    # Create a minimal valid favicon (1x1 pixel ICO)
-    # This is a placeholder - users should replace with their own favicon
-    favicon_bytes =
-      <<0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 24, 0, 48, 0, 0, 0, 22, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0,
-        0, 2, 0, 0, 0, 1, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 255, 0, 0, 0, 0, 0>>
-
-    Igniter.create_new_file(igniter, "priv/static/favicon.ico", favicon_bytes, on_exists: :skip)
-  end
-
-  defp configure_esbuild(igniter, app_name, true) do
-    app_config =
-      {:code,
-       Sourceror.parse_string!("""
-       [
-         args:
-           ~w(js/app.js --bundle --target=es2022 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/*),
-         cd: Path.expand("../assets", __DIR__),
-         env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
-       ]
-       """)}
+    deploy_tasks =
+      if(tailwind?, do: ["tailwind #{app_name} --minify"], else: []) ++
+        ["esbuild #{app_name} --minify", "phx.digest"]
 
     igniter
-    |> Igniter.Project.Config.configure(
-      "config.exs",
-      :esbuild,
-      [:version],
-      "0.25.4"
-    )
-    |> Igniter.Project.Config.configure(
-      "config.exs",
-      :esbuild,
-      [app_name],
-      app_config,
-      updater: fn zipper -> {:ok, zipper} end
-    )
+    |> add_alias_if_missing("assets.setup", setup_tasks)
+    |> add_alias_if_missing("assets.build", build_tasks)
+    |> add_alias_if_missing("assets.deploy", deploy_tasks)
   end
 
-  defp configure_esbuild(igniter, _app_name, false), do: igniter
-
-  defp configure_tailwind(igniter, app_name, true) do
-    app_config =
-      {:code,
-       Sourceror.parse_string!("""
-       [
-         args: ~w(
-           --input=assets/css/app.css
-           --output=priv/static/assets/css/app.css
-         ),
-         cd: Path.expand("..", __DIR__)
-       ]
-       """)}
-
-    igniter
-    |> Igniter.Project.Config.configure(
-      "config.exs",
-      :tailwind,
-      [:version],
-      "4.1.12"
-    )
-    |> Igniter.Project.Config.configure(
-      "config.exs",
-      :tailwind,
-      [app_name],
-      app_config,
-      updater: fn zipper -> {:ok, zipper} end
-    )
-  end
-
-  defp configure_tailwind(igniter, _app_name, false), do: igniter
-
-  defp configure_watchers(igniter, app_name, endpoint_module, esbuild?, tailwind?) do
-    watchers = build_watchers(app_name, esbuild?, tailwind?)
-
-    if watchers == [] do
-      igniter
-    else
-      watchers_code = {:code, Sourceror.parse_string!(inspect(watchers))}
-
-      Igniter.Project.Config.configure(
-        igniter,
-        "dev.exs",
-        app_name,
-        [endpoint_module, :watchers],
-        watchers_code,
-        updater: fn zipper -> {:ok, zipper} end
-      )
-    end
-  end
-
-  defp build_watchers(app_name, esbuild?, tailwind?) do
-    esbuild_watcher =
-      if esbuild? do
-        [{:esbuild, {Esbuild, :install_and_run, [app_name, ~w(--sourcemap=inline --watch)]}}]
-      else
-        []
-      end
-
-    tailwind_watcher =
-      if tailwind? do
-        [{:tailwind, {Tailwind, :install_and_run, [app_name, ~w(--watch)]}}]
-      else
-        []
-      end
-
-    esbuild_watcher ++ tailwind_watcher
-  end
-
-  defp configure_live_reload(igniter, app_name, endpoint_module) do
-    live_reload_config =
-      {:code,
-       Sourceror.parse_string!("""
-       [
-         web_console_logger: true,
-         patterns: [
-           ~r"priv/static/(?!uploads/).*\\.(js|css|png|jpeg|jpg|gif|svg)$",
-           ~r"lib/.*_web/router\\.ex$",
-           ~r"lib/.*_web/(controllers|live|components)/.*\\.(ex|heex)$"
-         ]
-       ]
-       """)}
-
-    Igniter.Project.Config.configure(
-      igniter,
-      "dev.exs",
-      app_name,
-      [endpoint_module, :live_reload],
-      live_reload_config,
-      updater: fn zipper -> {:ok, zipper} end
-    )
-  end
-
-  defp add_asset_aliases(igniter, app_name, esbuild?, tailwind?) do
-    asset_builders = build_asset_builders(esbuild?, tailwind?)
-
-    if asset_builders == [] do
-      igniter
-    else
-      setup_tasks = Enum.map(asset_builders, &"#{&1}.install --if-missing")
-      build_tasks = ["compile" | Enum.map(asset_builders, &"#{&1} #{app_name}")]
-      deploy_tasks = Enum.map(asset_builders, &"#{&1} #{app_name} --minify") ++ ["phx.digest"]
-
-      igniter
-      |> add_alias_if_missing("assets.setup", setup_tasks)
-      |> add_alias_if_missing("assets.build", build_tasks)
-      |> add_alias_if_missing("assets.deploy", deploy_tasks)
-      |> update_setup_alias(asset_builders)
-    end
-  end
-
-  defp build_asset_builders(esbuild?, tailwind?) do
-    esbuild = if esbuild?, do: ["esbuild"], else: []
-    tailwind = if tailwind?, do: ["tailwind"], else: []
-    esbuild ++ tailwind
-  end
+  defp maybe_add_aliases(igniter, _app_name, _bundler, _tailwind?), do: igniter
 
   defp add_alias_if_missing(igniter, alias_name, tasks) do
     Igniter.Project.TaskAliases.add_alias(igniter, alias_name, tasks, if_exists: :ignore)
   end
 
-  defp update_setup_alias(igniter, _asset_builders) do
+  defp update_setup_alias(igniter) do
     igniter
     |> Igniter.Project.TaskAliases.add_alias(
       "setup",

--- a/lib/mix/tasks/phx/install/assets/esbuild.ex
+++ b/lib/mix/tasks/phx/install/assets/esbuild.ex
@@ -1,0 +1,404 @@
+defmodule Mix.Tasks.Phx.Install.Assets.Esbuild do
+  @shortdoc "Sets up JavaScript bundling with esbuild"
+  @moduledoc """
+  Sets up JavaScript bundling with esbuild.
+
+  This task sets up:
+  - `esbuild` dependency
+  - `assets/js/app.js` or `assets/js/app.ts` - JavaScript/TypeScript entry point
+  - `assets/vendor/topbar.js` - Progress indicator for LiveView
+  - esbuild configuration in config.exs
+  - esbuild watcher in dev.exs
+
+  ## Usage
+
+      mix phx.install.assets.esbuild
+      mix phx.install.assets.esbuild --lang ts
+
+  ## Options
+
+  - `--lang` - Language for the entry point: "js" (default) or "ts"
+
+  This task is typically composed by `mix phx.install.assets` rather than called directly.
+  """
+  use Igniter.Mix.Task
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _composing_task) do
+    %Igniter.Mix.Task.Info{
+      group: :phoenix,
+      example: "mix phx.install.assets.esbuild",
+      adds_deps: [{:esbuild, "~> 0.10"}],
+      schema: [lang: :string],
+      defaults: [lang: "js"]
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    app_name = Igniter.Project.Application.app_name(igniter)
+    web_module = Igniter.Libs.Phoenix.web_module(igniter)
+    endpoint_module = Module.concat(web_module, Endpoint)
+
+    opts = igniter.args.options
+    ts? = opts[:lang] == "ts"
+
+    igniter
+    |> Igniter.Project.Deps.add_dep({:esbuild, "~> 0.10"}, on_exists: :skip)
+    |> set_runtime_dep()
+    |> create_app_entry(web_module, ts?)
+    |> create_topbar_js()
+    |> configure_esbuild(app_name, ts?)
+    |> configure_watcher(app_name, endpoint_module)
+  end
+
+  defp set_runtime_dep(igniter) do
+    Igniter.Project.Deps.set_dep_option(
+      igniter,
+      :esbuild,
+      :runtime,
+      Sourceror.parse_string!("Mix.env() == :dev")
+    )
+  end
+
+  defp create_app_entry(igniter, _web_module, false) do
+    content = """
+    // If you want to use Phoenix channels, run `mix help phx.gen.channel`
+    // to get started and then uncomment the line below.
+    // import "./user_socket.js"
+
+    // You can include dependencies in two ways.
+    //
+    // The simplest option is to put them in assets/vendor and
+    // import them using relative paths:
+    //
+    //     import "../vendor/some-package.js"
+    //
+    // Alternatively, you can `npm install some-package --prefix assets` and import
+    // them using a path starting with the package name:
+    //
+    //     import "some-package"
+    //
+
+    // Include phoenix_html to handle method=PUT/DELETE in forms and buttons.
+    import "phoenix_html"
+    // Establish Phoenix Socket and LiveView configuration.
+    import {Socket} from "phoenix"
+    import {LiveSocket} from "phoenix_live_view"
+    import topbar from "../vendor/topbar"
+
+    const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
+    const liveSocket = new LiveSocket("/live", Socket, {
+      longPollFallbackMs: 2500,
+      params: {_csrf_token: csrfToken}
+    })
+
+    // Show progress bar on live navigation and form submits
+    topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})
+    window.addEventListener("phx:page-loading-start", _info => topbar.show(300))
+    window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
+
+    // connect if there are any LiveViews on the page
+    liveSocket.connect()
+
+    // expose liveSocket on window for web console debug logs and latency simulation:
+    // >> liveSocket.enableDebug()
+    // >> liveSocket.enableLatencySim(1000)  // enabled for duration of browser session
+    // >> liveSocket.disableLatencySim()
+    window.liveSocket = liveSocket
+
+    // The lines below enable quality of life phoenix_live_reload
+    // development features:
+    //
+    //     1. stream server logs to the browser console
+    //     2. click on elements to jump to their definitions in your code editor
+    //
+    if (process.env.NODE_ENV === "development") {
+      window.addEventListener("phx:live_reload:attached", ({detail: reloader}) => {
+        // Enable server log streaming to client.
+        // Disable with reloader.disableServerLogs()
+        reloader.enableServerLogs()
+
+        // Open configured PLUG_EDITOR at file:line of the clicked element's HEEx component
+        //
+        //   * click with "c" key pressed to open at caller location
+        //   * click with "d" key pressed to open at function component definition location
+        let keyDown
+        window.addEventListener("keydown", e => keyDown = e.key)
+        window.addEventListener("keyup", _e => keyDown = null)
+        window.addEventListener("click", e => {
+          if(keyDown === "c"){
+            e.preventDefault()
+            e.stopImmediatePropagation()
+            reloader.openEditorAtCaller(e.target)
+          } else if(keyDown === "d"){
+            e.preventDefault()
+            e.stopImmediatePropagation()
+            reloader.openEditorAtDef(e.target)
+          }
+        }, true)
+
+        window.liveReloader = reloader
+      })
+    }
+    """
+
+    Igniter.create_new_file(igniter, "assets/js/app.js", content, on_exists: :skip)
+  end
+
+  defp create_app_entry(igniter, _web_module, true) do
+    content = """
+    import "phoenix_html"
+    import {Socket} from "phoenix"
+    import {LiveSocket} from "phoenix_live_view"
+    import topbar from "../vendor/topbar"
+
+    declare global {
+      interface Window {
+        liveSocket: LiveSocket
+        liveReloader: unknown
+      }
+    }
+
+    function connectLiveSocket(): LiveSocket {
+      const csrfToken = document.querySelector<HTMLMetaElement>("meta[name='csrf-token']")!.content
+      const liveSocket = new LiveSocket("/live", Socket, {
+        longPollFallbackMs: 2500,
+        params: {_csrf_token: csrfToken},
+      })
+      liveSocket.connect()
+      return liveSocket
+    }
+
+    function setupTopbar() {
+      topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})
+      window.addEventListener("phx:page-loading-start", () => topbar.show(300))
+      window.addEventListener("phx:page-loading-stop", () => topbar.hide())
+    }
+
+    function setupDevTools() {
+      window.addEventListener("phx:live_reload:attached", ({detail: reloader}: CustomEvent) => {
+        reloader.enableServerLogs()
+
+        let keyDown: string | null = null
+        window.addEventListener("keydown", (e: KeyboardEvent) => keyDown = e.key)
+        window.addEventListener("keyup", () => keyDown = null)
+        window.addEventListener("click", (e: MouseEvent) => {
+          if (keyDown === "c") {
+            e.preventDefault()
+            e.stopImmediatePropagation()
+            reloader.openEditorAtCaller(e.target)
+          } else if (keyDown === "d") {
+            e.preventDefault()
+            e.stopImmediatePropagation()
+            reloader.openEditorAtDef(e.target)
+          }
+        }, true)
+
+        window.liveReloader = reloader
+      })
+    }
+
+    setupTopbar()
+    window.liveSocket = connectLiveSocket()
+
+    if (process.env.NODE_ENV === "development") {
+      setupDevTools()
+    }
+    """
+
+    Igniter.create_new_file(igniter, "assets/js/app.ts", content, on_exists: :skip)
+  end
+
+  defp create_topbar_js(igniter) do
+    content = """
+    /**
+     * @license MIT
+     * topbar 3.0.0
+     * http://buunguyen.github.io/topbar
+     * Copyright (c) 2024 Buu Nguyen
+     */
+    (function (window, document) {
+      "use strict";
+
+      var canvas,
+        currentProgress,
+        showing,
+        progressTimerId = null,
+        fadeTimerId = null,
+        delayTimerId = null,
+        addEvent = function (elem, type, handler) {
+          if (elem.addEventListener) elem.addEventListener(type, handler, false);
+          else if (elem.attachEvent) elem.attachEvent("on" + type, handler);
+          else elem["on" + type] = handler;
+        },
+        options = {
+          autoRun: true,
+          barThickness: 3,
+          barColors: {
+            0: "rgba(26,  188, 156, .9)",
+            ".25": "rgba(52,  152, 219, .9)",
+            ".50": "rgba(241, 196, 15,  .9)",
+            ".75": "rgba(230, 126, 34,  .9)",
+            "1.0": "rgba(211, 84,  0,   .9)",
+          },
+          shadowBlur: 10,
+          shadowColor: "rgba(0,   0,   0,   .6)",
+          className: null,
+        },
+        repaint = function () {
+          canvas.width = window.innerWidth;
+          canvas.height = options.barThickness * 5; // need space for shadow
+
+          var ctx = canvas.getContext("2d");
+          ctx.shadowBlur = options.shadowBlur;
+          ctx.shadowColor = options.shadowColor;
+
+          var lineGradient = ctx.createLinearGradient(0, 0, canvas.width, 0);
+          for (var stop in options.barColors)
+            lineGradient.addColorStop(stop, options.barColors[stop]);
+          ctx.lineWidth = options.barThickness;
+          ctx.beginPath();
+          ctx.moveTo(0, options.barThickness / 2);
+          ctx.lineTo(
+            Math.ceil(currentProgress * canvas.width),
+            options.barThickness / 2
+          );
+          ctx.strokeStyle = lineGradient;
+          ctx.stroke();
+        },
+        createCanvas = function () {
+          canvas = document.createElement("canvas");
+          var style = canvas.style;
+          style.position = "fixed";
+          style.top = style.left = style.right = style.margin = style.padding = 0;
+          style.zIndex = 100001;
+          style.display = "none";
+          if (options.className) canvas.classList.add(options.className);
+          addEvent(window, "resize", repaint);
+        },
+        topbar = {
+          config: function (opts) {
+            for (var key in opts)
+              if (options.hasOwnProperty(key)) options[key] = opts[key];
+          },
+          show: function (delay) {
+            if (showing) return;
+            if (delay) {
+              if (delayTimerId) return;
+              delayTimerId = setTimeout(() => topbar.show(), delay);
+            } else {
+              showing = true;
+              if (fadeTimerId !== null) window.cancelAnimationFrame(fadeTimerId);
+              if (!canvas) createCanvas();
+              if (!canvas.parentElement) document.body.appendChild(canvas);
+              canvas.style.opacity = 1;
+              canvas.style.display = "block";
+              topbar.progress(0);
+              if (options.autoRun) {
+                (function loop() {
+                  progressTimerId = window.requestAnimationFrame(loop);
+                  topbar.progress(
+                    "+" + 0.05 * Math.pow(1 - Math.sqrt(currentProgress), 2)
+                  );
+                })();
+              }
+            }
+          },
+          progress: function (to) {
+            if (typeof to === "undefined") return currentProgress;
+            if (typeof to === "string") {
+              to =
+                (to.indexOf("+") >= 0 || to.indexOf("-") >= 0
+                  ? currentProgress
+                  : 0) + parseFloat(to);
+            }
+            currentProgress = to > 1 ? 1 : to;
+            repaint();
+            return currentProgress;
+          },
+          hide: function () {
+            clearTimeout(delayTimerId);
+            delayTimerId = null;
+            if (!showing) return;
+            showing = false;
+            if (progressTimerId != null) {
+              window.cancelAnimationFrame(progressTimerId);
+              progressTimerId = null;
+            }
+            (function loop() {
+              if (topbar.progress("+.1") >= 1) {
+                canvas.style.opacity -= 0.05;
+                if (canvas.style.opacity <= 0.05) {
+                  canvas.style.display = "none";
+                  fadeTimerId = null;
+                  return;
+                }
+              }
+              fadeTimerId = window.requestAnimationFrame(loop);
+            })();
+          },
+        };
+
+      if (typeof module === "object" && typeof module.exports === "object") {
+        module.exports = topbar;
+      } else if (typeof define === "function" && define.amd) {
+        define(function () {
+          return topbar;
+        });
+      } else {
+        this.topbar = topbar;
+      }
+    }.call(this, window, document));
+    """
+
+    Igniter.create_new_file(igniter, "assets/vendor/topbar.js", content, on_exists: :skip)
+  end
+
+  defp configure_esbuild(igniter, app_name, ts?) do
+    entry_point = if ts?, do: "js/app.ts", else: "js/app.js"
+
+    app_config =
+      {:code,
+       Sourceror.parse_string!("""
+       [
+         args:
+           ~w(#{entry_point} --bundle --target=es2022 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/*),
+         cd: Path.expand("../assets", __DIR__),
+         env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
+       ]
+       """)}
+
+    igniter
+    |> Igniter.Project.Config.configure(
+      "config.exs",
+      :esbuild,
+      [:version],
+      "0.25.4"
+    )
+    |> Igniter.Project.Config.configure(
+      "config.exs",
+      :esbuild,
+      [app_name],
+      app_config,
+      updater: fn zipper -> {:ok, zipper} end
+    )
+  end
+
+  defp configure_watcher(igniter, app_name, endpoint_module) do
+    watcher_value =
+      {:code,
+       Sourceror.parse_string!(
+         "{Esbuild, :install_and_run, [#{inspect(app_name)}, ~w(--sourcemap=inline --watch)]}"
+       )}
+
+    Igniter.Project.Config.configure(
+      igniter,
+      "dev.exs",
+      app_name,
+      [endpoint_module, :watchers, :esbuild],
+      watcher_value,
+      updater: fn zipper -> {:ok, zipper} end
+    )
+  end
+end

--- a/lib/mix/tasks/phx/install/assets/live_reload.ex
+++ b/lib/mix/tasks/phx/install/assets/live_reload.ex
@@ -1,0 +1,53 @@
+defmodule Mix.Tasks.Phx.Install.Assets.LiveReload do
+  @shortdoc "Configures live reload for development"
+  @moduledoc """
+  Configures Phoenix live reload for development.
+
+  This task sets up the `live_reload` configuration in `dev.exs` which
+  watches for file changes and triggers browser reloads during development.
+
+  ## Usage
+
+      mix phx.install.assets.live_reload
+
+  This task is typically composed by `mix phx.install.assets` rather than called directly.
+  """
+  use Igniter.Mix.Task
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _composing_task) do
+    %Igniter.Mix.Task.Info{
+      group: :phoenix,
+      example: "mix phx.install.assets.live_reload"
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    app_name = Igniter.Project.Application.app_name(igniter)
+    web_module = Igniter.Libs.Phoenix.web_module(igniter)
+    endpoint_module = Module.concat(web_module, Endpoint)
+
+    live_reload_config =
+      {:code,
+       Sourceror.parse_string!("""
+       [
+         web_console_logger: true,
+         patterns: [
+           ~r"priv/static/(?!uploads/).*\\.(js|css|png|jpeg|jpg|gif|svg)$",
+           ~r"lib/.*_web/router\\.ex$",
+           ~r"lib/.*_web/(controllers|live|components)/.*\\.(ex|heex)$"
+         ]
+       ]
+       """)}
+
+    Igniter.Project.Config.configure(
+      igniter,
+      "dev.exs",
+      app_name,
+      [endpoint_module, :live_reload],
+      live_reload_config,
+      updater: fn zipper -> {:ok, zipper} end
+    )
+  end
+end

--- a/lib/mix/tasks/phx/install/assets/static.ex
+++ b/lib/mix/tasks/phx/install/assets/static.ex
@@ -1,0 +1,53 @@
+defmodule Mix.Tasks.Phx.Install.Assets.Static do
+  @shortdoc "Creates static placeholder files (robots.txt, favicon)"
+  @moduledoc """
+  Creates static placeholder files for a Phoenix application.
+
+  This task creates:
+  - `priv/static/robots.txt` - Robots exclusion file
+  - `priv/static/favicon.ico` - Default favicon placeholder
+
+  ## Usage
+
+      mix phx.install.assets.static
+
+  This task is typically composed by `mix phx.install.assets` rather than called directly.
+  """
+  use Igniter.Mix.Task
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _composing_task) do
+    %Igniter.Mix.Task.Info{
+      group: :phoenix,
+      example: "mix phx.install.assets.static"
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    igniter
+    |> create_robots_txt()
+    |> create_favicon()
+  end
+
+  defp create_robots_txt(igniter) do
+    content = """
+    # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+    #
+    # To ban all spiders from the entire site uncomment the next two lines:
+    # User-agent: *
+    # Disallow: /
+    """
+
+    Igniter.create_new_file(igniter, "priv/static/robots.txt", content, on_exists: :skip)
+  end
+
+  defp create_favicon(igniter) do
+    favicon_bytes =
+      <<0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0, 24, 0, 48, 0, 0, 0, 22, 0, 0, 0, 40, 0, 0, 0, 1, 0, 0,
+        0, 2, 0, 0, 0, 1, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 255, 0, 0, 0, 0, 0>>
+
+    Igniter.create_new_file(igniter, "priv/static/favicon.ico", favicon_bytes, on_exists: :skip)
+  end
+end

--- a/lib/mix/tasks/phx/install/assets/tailwind.ex
+++ b/lib/mix/tasks/phx/install/assets/tailwind.ex
@@ -1,0 +1,79 @@
+defmodule Mix.Tasks.Phx.Install.Assets.Tailwind do
+  @shortdoc "Sets up Tailwind CSS"
+  @moduledoc """
+  Sets up Tailwind CSS for a Phoenix application.
+
+  Creates the `assets/css/app.css` entry point, then dynamically composes a
+  bundler-specific runner task based on the `--bundler` flag:
+
+  - `phx.install.assets.tailwind.esbuild` - uses the `tailwind` hex package
+
+  To add support for a new bundler, implement a task at
+  `phx.install.assets.tailwind.<bundler_name>`.
+
+  ## Usage
+
+      mix phx.install.assets.tailwind
+      mix phx.install.assets.tailwind --bundler esbuild
+
+  ## Options
+
+  - `--bundler` - Which bundler is in use: "esbuild" (default)
+
+  This task is typically composed by `mix phx.install.assets` rather than called directly.
+  """
+  use Igniter.Mix.Task
+
+  @impl Igniter.Mix.Task
+  def info(argv, _composing_task) do
+    {parsed, _, _} = OptionParser.parse(argv, strict: [bundler: :string])
+    bundler = Keyword.get(parsed, :bundler, "esbuild")
+
+    %Igniter.Mix.Task.Info{
+      group: :phoenix,
+      example: "mix phx.install.assets.tailwind",
+      schema: [bundler: :string],
+      defaults: [bundler: "esbuild"],
+      composes: ["phx.install.assets.tailwind.#{bundler}"]
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    web_module = Igniter.Libs.Phoenix.web_module(igniter)
+
+    opts = igniter.args.options
+    bundler = opts[:bundler] || "esbuild"
+
+    igniter
+    |> create_app_css(web_module)
+    |> Igniter.compose_task("phx.install.assets.tailwind.#{bundler}")
+  end
+
+  defp create_app_css(igniter, web_module) do
+    lib_web_name =
+      web_module
+      |> Module.split()
+      |> List.last()
+      |> Macro.underscore()
+
+    content = """
+    /* See the Tailwind configuration guide for advanced usage
+       https://tailwindcss.com/docs/configuration */
+
+    @import "tailwindcss";
+    @source "../js";
+    @source "../../lib/#{lib_web_name}";
+
+    /* Add variants based on LiveView classes */
+    @custom-variant phx-click-loading (.phx-click-loading&, .phx-click-loading &);
+    @custom-variant phx-submit-loading (.phx-submit-loading&, .phx-submit-loading &);
+    @custom-variant phx-change-loading (.phx-change-loading&, .phx-change-loading &);
+
+    /* Make LiveView wrapper divs transparent for layout */
+    [data-phx-session], [data-phx-teleported-src] { display: contents }
+    """
+
+    Igniter.create_new_file(igniter, "assets/css/app.css", content, on_exists: :skip)
+  end
+end

--- a/lib/mix/tasks/phx/install/assets/tailwind/esbuild.ex
+++ b/lib/mix/tasks/phx/install/assets/tailwind/esbuild.ex
@@ -1,0 +1,90 @@
+defmodule Mix.Tasks.Phx.Install.Assets.Tailwind.Esbuild do
+  @shortdoc "Configures Tailwind CSS runner for esbuild"
+  @moduledoc """
+  Configures Tailwind CSS to run via the `tailwind` hex package (standalone CLI).
+
+  This task sets up:
+  - `tailwind` hex dependency
+  - Tailwind version and profile configuration in config.exs
+  - Tailwind watcher in dev.exs
+
+  ## Usage
+
+      mix phx.install.assets.tailwind.esbuild
+
+  This task is typically composed by `mix phx.install.assets.tailwind` rather than called directly.
+  """
+  use Igniter.Mix.Task
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _composing_task) do
+    %Igniter.Mix.Task.Info{
+      group: :phoenix,
+      example: "mix phx.install.assets.tailwind.esbuild",
+      adds_deps: [{:tailwind, "~> 0.3"}]
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    app_name = Igniter.Project.Application.app_name(igniter)
+    web_module = Igniter.Libs.Phoenix.web_module(igniter)
+    endpoint_module = Module.concat(web_module, Endpoint)
+
+    igniter
+    |> Igniter.Project.Deps.add_dep({:tailwind, "~> 0.3"}, on_exists: :skip)
+    |> set_runtime_dep()
+    |> configure_tailwind(app_name)
+    |> configure_watcher(app_name, endpoint_module)
+  end
+
+  defp set_runtime_dep(igniter) do
+    Igniter.Project.Deps.set_dep_option(
+      igniter,
+      :tailwind,
+      :runtime,
+      Sourceror.parse_string!("Mix.env() == :dev")
+    )
+  end
+
+  defp configure_tailwind(igniter, app_name) do
+    app_config =
+      {:code,
+       Sourceror.parse_string!("""
+       [
+         args: ~w(
+           --input=assets/css/app.css
+           --output=priv/static/assets/css/app.css
+         ),
+         cd: Path.expand("..", __DIR__)
+       ]
+       """)}
+
+    igniter
+    |> Igniter.Project.Config.configure("config.exs", :tailwind, [:version], "4.1.12")
+    |> Igniter.Project.Config.configure(
+      "config.exs",
+      :tailwind,
+      [app_name],
+      app_config,
+      updater: fn zipper -> {:ok, zipper} end
+    )
+  end
+
+  defp configure_watcher(igniter, app_name, endpoint_module) do
+    watcher_value =
+      {:code,
+       Sourceror.parse_string!(
+         "{Tailwind, :install_and_run, [#{inspect(app_name)}, ~w(--watch)]}"
+       )}
+
+    Igniter.Project.Config.configure(
+      igniter,
+      "dev.exs",
+      app_name,
+      [endpoint_module, :watchers, :tailwind],
+      watcher_value,
+      updater: fn zipper -> {:ok, zipper} end
+    )
+  end
+end

--- a/test/mix/tasks/phx/install/assets_test.exs
+++ b/test/mix/tasks/phx/install/assets_test.exs
@@ -3,76 +3,29 @@ defmodule Mix.Tasks.Phx.Install.AssetsTest do
 
   import Igniter.Test
 
-  describe "phx.install.assets" do
-    test "declares esbuild and tailwind dependencies" do
-      info = Mix.Tasks.Phx.Install.Assets.info([], nil)
-
-      assert Enum.any?(info.adds_deps, fn dep -> elem(dep, 0) == :esbuild end)
-      assert Enum.any?(info.adds_deps, fn dep -> elem(dep, 0) == :tailwind end)
-    end
-
-    test "creates assets/js/app.js" do
+  describe "phx.install.assets with esbuild (default)" do
+    test "creates app.js and topbar.js" do
       test_project()
       |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
       |> Igniter.compose_task("phx.install.assets")
       |> assert_creates("assets/js/app.js")
     end
 
-    test "app.js includes LiveSocket setup" do
-      igniter =
-        test_project()
-        |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.assets")
-        |> apply_igniter!()
-
-      source = Rewrite.source!(igniter.rewrite, "assets/js/app.js")
-      content = Rewrite.Source.get(source, :content)
-
-      assert content =~ "LiveSocket"
-      assert content =~ "phoenix_live_view"
-      assert content =~ "liveSocket.connect()"
-    end
-
-    test "creates assets/css/app.css" do
+    test "creates app.css" do
       test_project()
       |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
       |> Igniter.compose_task("phx.install.assets")
       |> assert_creates("assets/css/app.css")
     end
 
-    test "app.css includes Tailwind imports" do
+    test "creates static files" do
       igniter =
         test_project()
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
         |> Igniter.compose_task("phx.install.assets")
-        |> apply_igniter!()
 
-      source = Rewrite.source!(igniter.rewrite, "assets/css/app.css")
-      content = Rewrite.Source.get(source, :content)
-
-      assert content =~ "@import \"tailwindcss\""
-      assert content =~ "phx-click-loading"
-    end
-
-    test "creates assets/vendor/topbar.js" do
-      test_project()
-      |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-      |> Igniter.compose_task("phx.install.assets")
-      |> assert_creates("assets/vendor/topbar.js")
-    end
-
-    test "creates priv/static/robots.txt" do
-      test_project()
-      |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-      |> Igniter.compose_task("phx.install.assets")
-      |> assert_creates("priv/static/robots.txt")
-    end
-
-    test "creates priv/static/favicon.ico" do
-      test_project()
-      |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-      |> Igniter.compose_task("phx.install.assets")
-      |> assert_creates("priv/static/favicon.ico")
+      igniter |> assert_creates("priv/static/robots.txt")
+      igniter |> assert_creates("priv/static/favicon.ico")
     end
 
     test "configures esbuild in config.exs" do
@@ -87,7 +40,6 @@ defmodule Mix.Tasks.Phx.Install.AssetsTest do
 
       assert content =~ "config :esbuild"
       assert content =~ "js/app.js"
-      assert content =~ "--bundle"
     end
 
     test "configures tailwind in config.exs" do
@@ -114,7 +66,6 @@ defmodule Mix.Tasks.Phx.Install.AssetsTest do
       source = Rewrite.source!(igniter.rewrite, "config/dev.exs")
       content = Rewrite.Source.get(source, :content)
 
-      assert content =~ "watchers:"
       assert content =~ "esbuild:"
       assert content =~ "tailwind:"
     end
@@ -148,36 +99,6 @@ defmodule Mix.Tasks.Phx.Install.AssetsTest do
       assert content =~ "assets.deploy"
     end
 
-    test "respects --no-esbuild flag" do
-      info = Mix.Tasks.Phx.Install.Assets.info(["--no-esbuild"], nil)
-
-      refute Enum.any?(info.adds_deps, fn dep -> elem(dep, 0) == :esbuild end)
-      assert Enum.any?(info.adds_deps, fn dep -> elem(dep, 0) == :tailwind end)
-
-      igniter =
-        test_project()
-        |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.assets", ["--no-esbuild"])
-        |> apply_igniter!()
-
-      refute Map.has_key?(igniter.rewrite.sources, "assets/js/app.js")
-    end
-
-    test "respects --no-tailwind flag" do
-      info = Mix.Tasks.Phx.Install.Assets.info(["--no-tailwind"], nil)
-
-      assert Enum.any?(info.adds_deps, fn dep -> elem(dep, 0) == :esbuild end)
-      refute Enum.any?(info.adds_deps, fn dep -> elem(dep, 0) == :tailwind end)
-
-      igniter =
-        test_project()
-        |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.assets", ["--no-tailwind"])
-        |> apply_igniter!()
-
-      refute Map.has_key?(igniter.rewrite.sources, "assets/css/app.css")
-    end
-
     test "works with custom app name" do
       igniter =
         test_project(app_name: :my_app)
@@ -197,21 +118,106 @@ defmodule Mix.Tasks.Phx.Install.AssetsTest do
     end
 
     test "running twice does not produce errors" do
-      # First run
       igniter =
         test_project()
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
         |> Igniter.compose_task("phx.install.assets")
         |> apply_igniter!()
 
-      # Second run should succeed without errors
-      # Note: strict byte-for-byte idempotency isn't guaranteed due to Sourceror
-      # reformatting, but the task should not fail when run twice
-      result =
-        igniter
-        |> Igniter.compose_task("phx.install.assets")
+      result = Igniter.compose_task(igniter, "phx.install.assets")
 
       assert result.issues == []
+    end
+  end
+
+  describe "phx.install.assets --no-tailwind" do
+    test "skips tailwind configuration" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
+        |> Igniter.compose_task("phx.install.assets", ["--no-tailwind"])
+        |> apply_igniter!()
+
+      source = Rewrite.source!(igniter.rewrite, "config/config.exs")
+      content = Rewrite.Source.get(source, :content)
+
+      refute content =~ "config :tailwind"
+      refute Map.has_key?(igniter.rewrite.sources, "assets/css/app.css")
+    end
+
+    test "still creates JS assets" do
+      test_project()
+      |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
+      |> Igniter.compose_task("phx.install.assets", ["--no-tailwind"])
+      |> assert_creates("assets/js/app.js")
+    end
+  end
+
+  describe "phx.install.assets --lang ts" do
+    test "creates app.ts instead of app.js" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
+        |> Igniter.compose_task("phx.install.assets", ["--lang", "ts"])
+        |> apply_igniter!()
+
+      assert Map.has_key?(igniter.rewrite.sources, "assets/js/app.ts")
+      refute Map.has_key?(igniter.rewrite.sources, "assets/js/app.js")
+    end
+
+    test "configures esbuild to use .ts entry point" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
+        |> Igniter.compose_task("phx.install.assets", ["--lang", "ts"])
+        |> apply_igniter!()
+
+      source = Rewrite.source!(igniter.rewrite, "config/config.exs")
+      content = Rewrite.Source.get(source, :content)
+
+      assert content =~ "js/app.ts"
+    end
+  end
+
+  describe "phx.install.assets --bundler none" do
+    test "skips JS bundling entirely" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
+        |> Igniter.compose_task("phx.install.assets", ["--bundler", "none"])
+        |> apply_igniter!()
+
+      source = Rewrite.source!(igniter.rewrite, "config/config.exs")
+      content = Rewrite.Source.get(source, :content)
+
+      refute content =~ "config :esbuild"
+      refute Map.has_key?(igniter.rewrite.sources, "assets/js/app.js")
+      refute Map.has_key?(igniter.rewrite.sources, "assets/vendor/topbar.js")
+    end
+
+    test "still creates static files and live_reload" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
+        |> Igniter.compose_task("phx.install.assets", ["--bundler", "none"])
+        |> apply_igniter!()
+
+      assert Map.has_key?(igniter.rewrite.sources, "priv/static/robots.txt")
+
+      source = Rewrite.source!(igniter.rewrite, "config/dev.exs")
+      content = Rewrite.Source.get(source, :content)
+
+      assert content =~ "live_reload:"
+    end
+
+    test "still creates tailwind CSS when not explicitly disabled" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
+        |> Igniter.compose_task("phx.install.assets", ["--bundler", "none"])
+        |> apply_igniter!()
+
+      assert Map.has_key?(igniter.rewrite.sources, "assets/css/app.css")
     end
   end
 end


### PR DESCRIPTION
## Summary

- Refactors `phx.install.assets` from a monolithic task into a composable orchestrator with pluggable bundler and CSS runner subtasks
- Adds `--lang=ts` option for TypeScript entry point generation
- Tailwind CSS runner is dynamically dispatched via task naming convention (`phx.install.assets.tailwind.#{bundler}`), so adding a new bundler requires no changes to existing files

### New flags on `phx.install.assets`

| Flag | Values | Default |
|---|---|---|
| `--bundler` | `esbuild`, `none` | `esbuild` |
| `--lang` | `js`, `ts` | `js` |
| `--tailwind` | boolean | `true` |

### Task composition

```
phx.install.assets (orchestrator)
├── phx.install.assets.static
├── phx.install.assets.live_reload
├── phx.install.assets.esbuild (or other bundler)
└── phx.install.assets.tailwind
    └── phx.install.assets.tailwind.esbuild (or other bundler)
```

### Extensibility

Adding support for a new bundler (e.g. from an external package) requires implementing two tasks:
- `phx.install.assets.<bundler_name>` — JS bundling setup
- `phx.install.assets.tailwind.<bundler_name>` — Tailwind CSS runner for that bundler

No changes to existing files needed.

## Test plan

- [x] All 157 existing tests pass (0 failures)
- [x] New tests cover: esbuild default, `--no-tailwind`, `--lang ts`, `--bundler none`, custom app name, idempotency
- [x] `mix format --check-formatted` passes