### PR TITLE
Pluggable UI component library with DaisyUI support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,9 +29,24 @@ mix format
 
 ### Task Composition
 
-The main orchestrator `Mix.Tasks.Phx.Install` (`lib/mix/tasks/phx/install.ex`) composes individual installer tasks. Core tasks always run; optional tasks are controlled by flags (`--live`, `--assets`, `--gettext`, `--dashboard`).
+The main orchestrator `Mix.Tasks.Phx.Install` (`lib/mix/tasks/phx/install.ex`) composes individual installer tasks. Core tasks always run; optional tasks are controlled by flags (`--live`, `--assets`, `--gettext`, `--dashboard`, `--css`, `--ui`).
 
-**Composition order:** core → endpoint → router → (optional: live, gettext, assets, dashboard)
+**Composition order:** core → endpoint → router → (optional: ecto, mailer, live, gettext, assets, heroicons, html, components, page, dashboard)
+
+### Pluggable Architecture
+
+Several features use a dynamic task composition pattern where an orchestrator selects an implementation based on a flag:
+
+- **CSS framework** (`--css`): `assets/css.ex` orchestrator → `assets/css/tailwind.ex` (or future alternatives)
+- **UI components** (`--ui`): `html.ex` orchestrator → `html/daisy.ex` or `html/tailwind.ex`
+- **Data display components** (`--ui`): `components.ex` orchestrator → `components/daisy.ex` or `components/tailwind.ex`
+- **JS bundler** (`--bundler`): `assets.ex` orchestrator → `assets/esbuild.ex` (or future alternatives)
+
+Each orchestrator dynamically composes `phx.install.{area}.#{variant}` based on the flag value.
+
+### CSS Composition
+
+Each task that needs CSS creates its own file (e.g. `assets/css/phx-tailwind.css`, `assets/css/phx-daisy.css`, `assets/css/phx-heroicons.css`) and appends an `@import` line to `assets/css/app.css`. Tailwind v4 flattens imports before processing directives, so `@plugin`/`@source`/`@custom-variant` in imported files work correctly.
 
 ### Task Pattern
 
@@ -45,9 +60,11 @@ Tasks are idempotent — they use `find_and_update_or_create_module/4` and `crea
 
 ### Task Dependency Graph
 
-- `phx.install.live` composes `phx.install.html`
+- `phx.install.live` composes `phx.install.html` (passing `--ui` through)
+- `phx.install.html` composes `phx.install.html.{ui}` (daisy or tailwind)
+- `phx.install.components` composes `phx.install.components.{ui}`
+- `phx.install.assets` composes `phx.install.assets.css.{css}` (tailwind)
 - `phx.install.dashboard` requires live (guarded by `opts[:live] && opts[:dashboard]`)
-- `phx.install.html` is not directly invoked by the orchestrator — it's pulled in via `live`
 
 ### Entry Point for Package Installation
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,22 @@ mix igniter.new my_app --install phx_install
 
 ## Options
 
-By default, `mix phx.install` sets up a full Phoenix application with LiveView, assets, Gettext, and LiveDashboard. Use flags to opt out:
+By default, `mix phx.install` sets up a full Phoenix application with DaisyUI components, LiveView, assets, Gettext, and LiveDashboard.
+
+### UI and CSS options
+
+```bash
+# Default: DaisyUI components with Tailwind CSS (matches phx.new)
+mix phx.install
+
+# Plain Tailwind CSS without DaisyUI
+mix phx.install --ui tailwind
+
+# No CSS framework
+mix phx.install --css none --ui none
+```
+
+### Feature flags
 
 ```bash
 # API-only (no LiveView, no assets)
@@ -80,9 +95,9 @@ Each feature is a standalone task. The orchestrator (`mix phx.install`) composes
 | `phx.install.core`      | Application module, config files, base dependencies    |
 | `phx.install.endpoint`  | Phoenix.Endpoint, Telemetry, web module                |
 | `phx.install.router`    | Router with pipelines, error handling                  |
-| `phx.install.html`      | HTML components, layouts, error pages                  |
-| `phx.install.live`      | LiveView socket, helpers, and macros (composes `html`) |
-| `phx.install.assets`    | esbuild and Tailwind CSS                               |
+| `phx.install.html`      | HTML components, layouts, error pages (`--ui daisy\|tailwind`) |
+| `phx.install.live`      | LiveView socket, helpers, and macros (composes `html`)        |
+| `phx.install.assets`    | esbuild, CSS framework (`--css tailwind\|none`)               |
 | `phx.install.gettext`   | Internationalisation with Gettext                      |
 | `phx.install.dashboard` | Phoenix LiveDashboard (dev only)                       |
 | `phx.install.ecto`      | Ecto database support with Repo                        |

--- a/lib/mix/tasks/phx/install.ex
+++ b/lib/mix/tasks/phx/install.ex
@@ -19,6 +19,8 @@ defmodule Mix.Tasks.Phx.Install do
   - `--gettext` / `--no-gettext` - Include Gettext i18n (default: true)
   - `--dashboard` / `--no-dashboard` - Include LiveDashboard (default: true)
   - `--page` / `--no-page` - Include stock homepage (default: true)
+  - `--css` - CSS framework: "tailwind" (default) or "none"
+  - `--ui` - UI component library: "daisy" (default), "tailwind", or "none"
 
   ## What Gets Installed
 
@@ -31,17 +33,21 @@ defmodule Mix.Tasks.Phx.Install do
   - `phx.install.ecto` - Ecto database support, Repo, migrations
   - `phx.install.mailer` - Swoosh mailer and mailbox route
   - `phx.install.live` - LiveView socket and macros
-  - `phx.install.assets` - esbuild, tailwind configuration
+  - `phx.install.assets` - esbuild, CSS framework configuration
   - `phx.install.gettext` - Internationalization
   - `phx.install.heroicons` - Heroicon rendering (requires assets)
+  - `phx.install.html` - Core UI components (requires live)
   - `phx.install.components` - Data display components (requires live)
   - `phx.install.page` - Stock homepage with PageController
   - `phx.install.dashboard` - LiveDashboard in dev
 
   ## Examples
 
-      # Install with all defaults
+      # Install with all defaults (DaisyUI)
       mix phx.install
+
+      # Plain Tailwind CSS (no DaisyUI)
+      mix phx.install --ui tailwind
 
       # API-only (no LiveView, no assets)
       mix phx.install --no-live --no-assets
@@ -59,21 +65,25 @@ defmodule Mix.Tasks.Phx.Install do
       example: "mix phx.install --live --assets",
       schema: [
         assets: :boolean,
+        css: :string,
         dashboard: :boolean,
         ecto: :boolean,
         gettext: :boolean,
         live: :boolean,
         mailer: :boolean,
-        page: :boolean
+        page: :boolean,
+        ui: :string
       ],
       defaults: [
         assets: true,
+        css: "tailwind",
         dashboard: true,
         ecto: true,
         gettext: true,
         live: true,
         mailer: true,
-        page: true
+        page: true,
+        ui: "daisy"
       ],
       composes: [
         "phx.install.core",
@@ -85,6 +95,7 @@ defmodule Mix.Tasks.Phx.Install do
         "phx.install.assets",
         "phx.install.gettext",
         "phx.install.heroicons",
+        "phx.install.html",
         "phx.install.components",
         "phx.install.page",
         "phx.install.dashboard"
@@ -95,21 +106,40 @@ defmodule Mix.Tasks.Phx.Install do
   @impl Igniter.Mix.Task
   def igniter(igniter) do
     opts = igniter.args.options
+    ui = opts[:ui] || "daisy"
+    css = opts[:css] || "tailwind"
 
     igniter
+    |> validate_options(ui, css)
     |> Igniter.compose_task("phx.install.core")
     |> Igniter.compose_task("phx.install.endpoint")
     |> Igniter.compose_task("phx.install.router")
     |> maybe_compose("phx.install.ecto", opts[:ecto])
     |> maybe_compose("phx.install.mailer", opts[:mailer])
-    |> maybe_compose("phx.install.live", opts[:live])
+    |> maybe_compose("phx.install.live", opts[:live], ["--ui", ui])
     |> maybe_compose("phx.install.gettext", opts[:gettext])
-    |> maybe_compose("phx.install.assets", opts[:assets])
+    |> maybe_compose("phx.install.assets", opts[:assets], ["--css", css])
     |> maybe_compose("phx.install.heroicons", opts[:assets])
-    |> maybe_compose("phx.install.components", opts[:live])
-    |> maybe_compose("phx.install.page", opts[:live] && opts[:page])
+    |> maybe_compose("phx.install.components", opts[:live], ["--ui", ui])
+    |> maybe_compose("phx.install.page", opts[:live] && opts[:page], ["--ui", ui])
     |> maybe_compose("phx.install.dashboard", opts[:live] && opts[:dashboard])
   end
+
+  defp validate_options(igniter, ui, css) do
+    if ui == "daisy" and css != "tailwind" do
+      Igniter.add_issue(igniter, """
+      Incompatible options: --ui daisy requires --css tailwind.
+
+      DaisyUI is a Tailwind CSS plugin and cannot be used without Tailwind.
+      Either use --css tailwind (default) or choose a different UI library with --ui tailwind.
+      """)
+    else
+      igniter
+    end
+  end
+
+  defp maybe_compose(igniter, _task, false, _args), do: igniter
+  defp maybe_compose(igniter, task, _, args), do: Igniter.compose_task(igniter, task, args)
 
   defp maybe_compose(igniter, _task, false), do: igniter
   defp maybe_compose(igniter, task, _), do: Igniter.compose_task(igniter, task)

--- a/lib/mix/tasks/phx/install/assets.ex
+++ b/lib/mix/tasks/phx/install/assets.ex
@@ -10,14 +10,14 @@ defmodule Mix.Tasks.Phx.Install.Assets do
 
       mix phx.install.assets
       mix phx.install.assets --bundler esbuild --lang ts
-      mix phx.install.assets --no-tailwind
+      mix phx.install.assets --css none
       mix phx.install.assets --bundler none
 
   ## Options
 
   - `--bundler` - JavaScript bundler to use: "esbuild" (default) or "none" to skip
   - `--lang` - Language for the JS entry point: "js" (default) or "ts"
-  - `--tailwind` / `--no-tailwind` - Include Tailwind CSS (default: true)
+  - `--css` - CSS framework to use: "tailwind" (default) or "none" to skip
 
   ## What Gets Installed
 
@@ -28,14 +28,16 @@ defmodule Mix.Tasks.Phx.Install.Assets do
   Based on `--bundler`:
   - `phx.install.assets.esbuild` - esbuild + vendored topbar
 
-  Optional:
-  - `phx.install.assets.tailwind` - Tailwind CSS (runner varies by bundler)
+  Based on `--css`:
+  - `phx.install.assets.css.tailwind` - Tailwind CSS (runner varies by bundler)
 
   ## Extensibility
 
-  To add support for a new bundler, implement two tasks:
-  - `phx.install.assets.<bundler_name>` - JS bundling setup
-  - `phx.install.assets.tailwind.<bundler_name>` - Tailwind CSS runner for that bundler
+  To add support for a new bundler, implement a task at
+  `phx.install.assets.<bundler_name>`.
+
+  To add support for a new CSS framework, implement a task at
+  `phx.install.assets.css.<framework_name>`.
 
   This task is typically called by `mix phx.install` rather than directly.
   """
@@ -45,25 +47,25 @@ defmodule Mix.Tasks.Phx.Install.Assets do
   def info(argv, _composing_task) do
     {parsed, _, _} =
       OptionParser.parse(argv,
-        strict: [bundler: :string, lang: :string, tailwind: :boolean]
+        strict: [bundler: :string, lang: :string, css: :string]
       )
 
     bundler = Keyword.get(parsed, :bundler, "esbuild")
-    tailwind? = Keyword.get(parsed, :tailwind, true)
+    css = Keyword.get(parsed, :css, "tailwind")
 
     bundler_tasks = if bundler == "none", do: [], else: ["phx.install.assets.#{bundler}"]
-    tailwind_tasks = if tailwind?, do: ["phx.install.assets.tailwind"], else: []
+    css_tasks = if css == "none", do: [], else: ["phx.install.assets.css"]
 
     %Igniter.Mix.Task.Info{
       group: :phoenix,
       example: "mix phx.install.assets",
-      schema: [bundler: :string, lang: :string, tailwind: :boolean],
-      defaults: [bundler: "esbuild", lang: "js", tailwind: true],
+      schema: [bundler: :string, lang: :string, css: :string],
+      defaults: [bundler: "esbuild", lang: "js", css: "tailwind"],
       composes:
         [
           "phx.install.assets.static",
           "phx.install.assets.live_reload"
-        ] ++ bundler_tasks ++ tailwind_tasks
+        ] ++ bundler_tasks ++ css_tasks
     }
   end
 
@@ -74,45 +76,56 @@ defmodule Mix.Tasks.Phx.Install.Assets do
     opts = igniter.args.options
     bundler = opts[:bundler] || "esbuild"
     lang = opts[:lang] || "js"
-    tailwind? = opts[:tailwind] != false
+    css = opts[:css] || "tailwind"
 
     igniter
     |> Igniter.compose_task("phx.install.assets.static")
     |> Igniter.compose_task("phx.install.assets.live_reload")
-    |> maybe_compose_bundler(bundler, lang, tailwind?)
-    |> maybe_compose_tailwind(tailwind?, bundler)
-    |> maybe_add_aliases(app_name, bundler, tailwind?)
+    |> maybe_compose_bundler(bundler, lang)
+    |> maybe_create_app_css(css)
+    |> maybe_compose_css(css, bundler)
+    |> maybe_add_aliases(app_name, bundler, css)
     |> update_setup_alias()
   end
 
-  defp maybe_compose_bundler(igniter, "none", _lang, _tailwind?), do: igniter
+  defp maybe_compose_bundler(igniter, "none", _lang), do: igniter
 
-  defp maybe_compose_bundler(igniter, bundler, lang, tailwind?) do
-    Igniter.compose_task(
-      igniter,
-      "phx.install.assets.#{bundler}",
-      bundler_args(lang, tailwind?)
-    )
+  defp maybe_compose_bundler(igniter, bundler, lang) do
+    Igniter.compose_task(igniter, "phx.install.assets.#{bundler}", ["--lang", lang])
   end
 
-  defp bundler_args(lang, tailwind?) do
-    ["--lang", lang] ++
-      if(tailwind?, do: [], else: ["--no-tailwind"])
+  defp maybe_create_app_css(igniter, "none"), do: igniter
+
+  defp maybe_create_app_css(igniter, _css) do
+    content = "/* This file is for your main application CSS */\n"
+    Igniter.create_new_file(igniter, "assets/css/app.css", content, on_exists: :skip)
   end
 
-  defp maybe_compose_tailwind(igniter, false, _bundler), do: igniter
+  defp maybe_compose_css(igniter, "none", _bundler), do: igniter
 
-  defp maybe_compose_tailwind(igniter, _tailwind?, "none") do
-    Igniter.compose_task(igniter, "phx.install.assets.tailwind", ["--bundler", "esbuild"])
+  defp maybe_compose_css(igniter, css, "none") do
+    Igniter.compose_task(igniter, "phx.install.assets.css", [
+      "--css",
+      css,
+      "--bundler",
+      "esbuild"
+    ])
   end
 
-  defp maybe_compose_tailwind(igniter, _tailwind?, bundler) do
-    Igniter.compose_task(igniter, "phx.install.assets.tailwind", ["--bundler", bundler])
+  defp maybe_compose_css(igniter, css, bundler) do
+    Igniter.compose_task(igniter, "phx.install.assets.css", [
+      "--css",
+      css,
+      "--bundler",
+      bundler
+    ])
   end
 
-  defp maybe_add_aliases(igniter, _app_name, "none", _tailwind?), do: igniter
+  defp maybe_add_aliases(igniter, _app_name, "none", _css), do: igniter
 
-  defp maybe_add_aliases(igniter, app_name, "esbuild", tailwind?) do
+  defp maybe_add_aliases(igniter, app_name, "esbuild", css) do
+    tailwind? = css == "tailwind"
+
     setup_tasks =
       ["esbuild.install --if-missing"] ++
         if(tailwind?, do: ["tailwind.install --if-missing"], else: [])
@@ -131,7 +144,7 @@ defmodule Mix.Tasks.Phx.Install.Assets do
     |> add_alias_if_missing("assets.deploy", deploy_tasks)
   end
 
-  defp maybe_add_aliases(igniter, _app_name, _bundler, _tailwind?), do: igniter
+  defp maybe_add_aliases(igniter, _app_name, _bundler, _css), do: igniter
 
   defp add_alias_if_missing(igniter, alias_name, tasks) do
     Igniter.Project.TaskAliases.add_alias(igniter, alias_name, tasks, if_exists: :ignore)

--- a/lib/mix/tasks/phx/install/assets/css.ex
+++ b/lib/mix/tasks/phx/install/assets/css.ex
@@ -1,0 +1,52 @@
+defmodule Mix.Tasks.Phx.Install.Assets.Css do
+  @shortdoc "Sets up the CSS framework"
+  @moduledoc """
+  Sets up the CSS framework for a Phoenix application.
+
+  This is an orchestrator that dynamically composes a CSS framework task
+  based on the `--css` flag.
+
+  ## Usage
+
+      mix phx.install.assets.css
+      mix phx.install.assets.css --css tailwind --bundler esbuild
+
+  ## Options
+
+  - `--css` - CSS framework to use: "tailwind" (default)
+  - `--bundler` - Which bundler is in use: "esbuild" (default)
+
+  ## Extensibility
+
+  To add support for a new CSS framework, implement a task at
+  `phx.install.assets.css.<framework_name>`.
+
+  This task is typically composed by `mix phx.install.assets` rather than called directly.
+  """
+  use Igniter.Mix.Task
+
+  @impl Igniter.Mix.Task
+  def info(argv, _composing_task) do
+    {parsed, _, _} =
+      OptionParser.parse(argv, strict: [css: :string, bundler: :string])
+
+    css = Keyword.get(parsed, :css, "tailwind")
+
+    %Igniter.Mix.Task.Info{
+      group: :phoenix,
+      example: "mix phx.install.assets.css",
+      schema: [css: :string, bundler: :string],
+      defaults: [css: "tailwind", bundler: "esbuild"],
+      composes: ["phx.install.assets.css.#{css}"]
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    opts = igniter.args.options
+    css = opts[:css] || "tailwind"
+    bundler = opts[:bundler] || "esbuild"
+
+    Igniter.compose_task(igniter, "phx.install.assets.css.#{css}", ["--bundler", bundler])
+  end
+end

--- a/lib/mix/tasks/phx/install/assets/css/tailwind.ex
+++ b/lib/mix/tasks/phx/install/assets/css/tailwind.ex
@@ -1,26 +1,30 @@
-defmodule Mix.Tasks.Phx.Install.Assets.Tailwind do
+defmodule Mix.Tasks.Phx.Install.Assets.Css.Tailwind do
   @shortdoc "Sets up Tailwind CSS"
   @moduledoc """
   Sets up Tailwind CSS for a Phoenix application.
 
-  Creates the `assets/css/app.css` entry point, then dynamically composes a
-  bundler-specific runner task based on the `--bundler` flag:
+  Creates `assets/css/phx-tailwind.css` with the Tailwind foundation
+  (import, source directives, LiveView custom variants) and appends an
+  `@import` line to `assets/css/app.css`.
 
-  - `phx.install.assets.tailwind.esbuild` - uses the `tailwind` hex package
+  Then dynamically composes a bundler-specific runner task based on
+  the `--bundler` flag:
+
+  - `phx.install.assets.css.tailwind.esbuild` - uses the `tailwind` hex package
 
   To add support for a new bundler, implement a task at
-  `phx.install.assets.tailwind.<bundler_name>`.
+  `phx.install.assets.css.tailwind.<bundler_name>`.
 
   ## Usage
 
-      mix phx.install.assets.tailwind
-      mix phx.install.assets.tailwind --bundler esbuild
+      mix phx.install.assets.css.tailwind
+      mix phx.install.assets.css.tailwind --bundler esbuild
 
   ## Options
 
   - `--bundler` - Which bundler is in use: "esbuild" (default)
 
-  This task is typically composed by `mix phx.install.assets` rather than called directly.
+  This task is typically composed by `mix phx.install.assets.css` rather than called directly.
   """
   use Igniter.Mix.Task
 
@@ -31,10 +35,10 @@ defmodule Mix.Tasks.Phx.Install.Assets.Tailwind do
 
     %Igniter.Mix.Task.Info{
       group: :phoenix,
-      example: "mix phx.install.assets.tailwind",
+      example: "mix phx.install.assets.css.tailwind",
       schema: [bundler: :string],
       defaults: [bundler: "esbuild"],
-      composes: ["phx.install.assets.tailwind.#{bundler}"]
+      composes: ["phx.install.assets.css.tailwind.#{bundler}"]
     }
   end
 
@@ -46,11 +50,12 @@ defmodule Mix.Tasks.Phx.Install.Assets.Tailwind do
     bundler = opts[:bundler] || "esbuild"
 
     igniter
-    |> create_app_css(web_module)
-    |> Igniter.compose_task("phx.install.assets.tailwind.#{bundler}")
+    |> create_tailwind_css(web_module)
+    |> PhxInstall.append_css_import(~s|@import "./phx-tailwind.css";|)
+    |> Igniter.compose_task("phx.install.assets.css.tailwind.#{bundler}")
   end
 
-  defp create_app_css(igniter, web_module) do
+  defp create_tailwind_css(igniter, web_module) do
     lib_web_name =
       web_module
       |> Module.split()
@@ -58,10 +63,8 @@ defmodule Mix.Tasks.Phx.Install.Assets.Tailwind do
       |> Macro.underscore()
 
     content = """
-    /* See the Tailwind configuration guide for advanced usage
-       https://tailwindcss.com/docs/configuration */
-
-    @import "tailwindcss";
+    @import "tailwindcss" source(none);
+    @source "../css";
     @source "../js";
     @source "../../lib/#{lib_web_name}";
 
@@ -74,6 +77,6 @@ defmodule Mix.Tasks.Phx.Install.Assets.Tailwind do
     [data-phx-session], [data-phx-teleported-src] { display: contents }
     """
 
-    Igniter.create_new_file(igniter, "assets/css/app.css", content, on_exists: :skip)
+    Igniter.create_new_file(igniter, "assets/css/phx-tailwind.css", content, on_exists: :skip)
   end
 end

--- a/lib/mix/tasks/phx/install/assets/css/tailwind/esbuild.ex
+++ b/lib/mix/tasks/phx/install/assets/css/tailwind/esbuild.ex
@@ -1,4 +1,4 @@
-defmodule Mix.Tasks.Phx.Install.Assets.Tailwind.Esbuild do
+defmodule Mix.Tasks.Phx.Install.Assets.Css.Tailwind.Esbuild do
   @shortdoc "Configures Tailwind CSS runner for esbuild"
   @moduledoc """
   Configures Tailwind CSS to run via the `tailwind` hex package (standalone CLI).
@@ -10,9 +10,9 @@ defmodule Mix.Tasks.Phx.Install.Assets.Tailwind.Esbuild do
 
   ## Usage
 
-      mix phx.install.assets.tailwind.esbuild
+      mix phx.install.assets.css.tailwind.esbuild
 
-  This task is typically composed by `mix phx.install.assets.tailwind` rather than called directly.
+  This task is typically composed by `mix phx.install.assets.css.tailwind` rather than called directly.
   """
   use Igniter.Mix.Task
 
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.Phx.Install.Assets.Tailwind.Esbuild do
   def info(_argv, _composing_task) do
     %Igniter.Mix.Task.Info{
       group: :phoenix,
-      example: "mix phx.install.assets.tailwind.esbuild",
+      example: "mix phx.install.assets.css.tailwind.esbuild",
       adds_deps: [{:tailwind, "~> 0.3"}]
     }
   end

--- a/lib/mix/tasks/phx/install/components.ex
+++ b/lib/mix/tasks/phx/install/components.ex
@@ -3,7 +3,10 @@ defmodule Mix.Tasks.Phx.Install.Components do
   @moduledoc """
   Adds data display components required by Phoenix generators.
 
-  This task adds the following components to CoreComponents:
+  This is an orchestrator that delegates to a UI-variant-specific task
+  based on the `--ui` flag.
+
+  The following components are added to CoreComponents:
   - `header/1` — page header with title, subtitle, and actions
   - `table/1` — data table with streaming support
   - `list/1` — data list with title/content pairs
@@ -13,6 +16,11 @@ defmodule Mix.Tasks.Phx.Install.Components do
   ## Usage
 
       mix phx.install.components
+      mix phx.install.components --ui tailwind
+
+  ## Options
+
+  - `--ui` — UI component library: "daisy" (default) or "tailwind"
 
   ## Prerequisites
 
@@ -25,161 +33,24 @@ defmodule Mix.Tasks.Phx.Install.Components do
   use Igniter.Mix.Task
 
   @impl Igniter.Mix.Task
-  def info(_argv, _composing_task) do
+  def info(argv, _composing_task) do
+    {parsed, _, _} = OptionParser.parse(argv, strict: [ui: :string])
+    ui = Keyword.get(parsed, :ui, "daisy")
+
     %Igniter.Mix.Task.Info{
       group: :phoenix,
-      example: "mix phx.install.components"
+      example: "mix phx.install.components",
+      schema: [ui: :string],
+      defaults: [ui: "daisy"],
+      composes: ["phx.install.components.#{ui}"]
     }
   end
 
   @impl Igniter.Mix.Task
   def igniter(igniter) do
-    web_module = Igniter.Libs.Phoenix.web_module(igniter)
-    core_components_module = Module.concat(web_module, CoreComponents)
+    opts = igniter.args.options
+    ui = opts[:ui] || "daisy"
 
-    igniter
-    |> add_header_component(core_components_module)
-    |> add_table_component(core_components_module)
-    |> add_list_component(core_components_module)
-  end
-
-  defp add_header_component(igniter, core_components_module) do
-    header_code = """
-    @doc \"\"\"
-    Renders a header with title.
-    \"\"\"
-    slot :inner_block, required: true
-    slot :subtitle
-    slot :actions
-
-    def header(assigns) do
-      ~H\"\"\"
-      <header class={[@actions != [] && "flex items-center justify-between gap-6", "pb-4"]}>
-        <div>
-          <h1 class="text-lg font-semibold leading-8">
-            {render_slot(@inner_block)}
-          </h1>
-          <p :if={@subtitle != []} class="text-sm text-base-content/70">
-            {render_slot(@subtitle)}
-          </p>
-        </div>
-        <div class="flex-none">{render_slot(@actions)}</div>
-      </header>
-      \"\"\"
-    end
-    """
-
-    add_component_if_missing(igniter, core_components_module, :header, 1, header_code)
-  end
-
-  defp add_table_component(igniter, core_components_module) do
-    table_code = """
-    @doc \"\"\"
-    Renders a table with generic styling.
-
-    ## Examples
-
-        <.table id="users" rows={@users}>
-          <:col :let={user} label="id">{user.id}</:col>
-          <:col :let={user} label="username">{user.username}</:col>
-        </.table>
-    \"\"\"
-    attr :id, :string, required: true
-    attr :rows, :list, required: true
-    attr :row_id, :any, default: nil, doc: "the function for generating the row id"
-    attr :row_click, :any, default: nil, doc: "the function for handling phx-click on each row"
-
-    attr :row_item, :any,
-      default: &Function.identity/1,
-      doc: "the function for mapping each row before calling the :col and :action slots"
-
-    slot :col, required: true do
-      attr :label, :string
-    end
-
-    slot :action, doc: "the slot for showing user actions in the last table column"
-
-    def table(assigns) do
-      assigns =
-        with %{rows: %Phoenix.LiveView.LiveStream{}} <- assigns do
-          assign(assigns, row_id: assigns.row_id || fn {id, _item} -> id end)
-        end
-
-      ~H\"\"\"
-      <table class="table table-zebra">
-        <thead>
-          <tr>
-            <th :for={col <- @col}>{col[:label]}</th>
-            <th :if={@action != []}>
-              <span class="sr-only">Actions</span>
-            </th>
-          </tr>
-        </thead>
-        <tbody id={@id} phx-update={is_struct(@rows, Phoenix.LiveView.LiveStream) && "stream"}>
-          <tr :for={row <- @rows} id={@row_id && @row_id.(row)}>
-            <td
-              :for={col <- @col}
-              phx-click={@row_click && @row_click.(row)}
-              class={@row_click && "hover:cursor-pointer"}
-            >
-              {render_slot(col, @row_item.(row))}
-            </td>
-            <td :if={@action != []} class="w-0 font-semibold">
-              <div class="flex gap-4">
-                <%= for action <- @action do %>
-                  {render_slot(action, @row_item.(row))}
-                <% end %>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      \"\"\"
-    end
-    """
-
-    add_component_if_missing(igniter, core_components_module, :table, 1, table_code)
-  end
-
-  defp add_list_component(igniter, core_components_module) do
-    list_code = """
-    @doc \"\"\"
-    Renders a data list.
-
-    ## Examples
-
-        <.list>
-          <:item title="Title">{@post.title}</:item>
-          <:item title="Views">{@post.views}</:item>
-        </.list>
-    \"\"\"
-    slot :item, required: true do
-      attr :title, :string, required: true
-    end
-
-    def list(assigns) do
-      ~H\"\"\"
-      <ul class="list">
-        <li :for={item <- @item} class="list-row">
-          <div class="list-col-grow">
-            <div class="font-bold">{item.title}</div>
-            <div>{render_slot(item)}</div>
-          </div>
-        </li>
-      </ul>
-      \"\"\"
-    end
-    """
-
-    add_component_if_missing(igniter, core_components_module, :list, 1, list_code)
-  end
-
-  defp add_component_if_missing(igniter, module, function_name, arity, code) do
-    Igniter.Project.Module.find_and_update_module!(igniter, module, fn zipper ->
-      case Igniter.Code.Function.move_to_def(zipper, function_name, arity) do
-        {:ok, _} -> {:ok, zipper}
-        :error -> {:ok, Igniter.Code.Common.add_code(zipper, code)}
-      end
-    end)
+    Igniter.compose_task(igniter, "phx.install.components.#{ui}")
   end
 end

--- a/lib/mix/tasks/phx/install/components/daisy.ex
+++ b/lib/mix/tasks/phx/install/components/daisy.ex
@@ -1,0 +1,179 @@
+defmodule Mix.Tasks.Phx.Install.Components.Daisy do
+  @shortdoc "Adds DaisyUI data display components"
+  @moduledoc """
+  Adds data display components for Phoenix generators using DaisyUI.
+
+  This task adds the following components to CoreComponents:
+  - `header/1` — page header with title, subtitle, and actions
+  - `table/1` — data table with streaming support
+  - `list/1` — data list with title/content pairs
+
+  These components are required by `phx.gen.html` and `phx.gen.live`.
+
+  ## Usage
+
+      mix phx.install.components.daisy
+
+  This task is typically composed by `mix phx.install.components` rather than directly.
+  """
+  use Igniter.Mix.Task
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _composing_task) do
+    %Igniter.Mix.Task.Info{
+      group: :phoenix,
+      example: "mix phx.install.components.daisy"
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    web_module = Igniter.Libs.Phoenix.web_module(igniter)
+    core_components_module = Module.concat(web_module, CoreComponents)
+
+    igniter
+    |> add_header_component(core_components_module)
+    |> add_table_component(core_components_module)
+    |> add_list_component(core_components_module)
+  end
+
+  defp add_header_component(igniter, core_components_module) do
+    code = """
+    @doc \"\"\"
+    Renders a header with title.
+    \"\"\"
+    slot :inner_block, required: true
+    slot :subtitle
+    slot :actions
+
+    def header(assigns) do
+      ~H\"\"\"
+      <header class={[@actions != [] && "flex items-center justify-between gap-6", "pb-4"]}>
+        <div>
+          <h1 class="text-lg font-semibold leading-8">
+            {render_slot(@inner_block)}
+          </h1>
+          <p :if={@subtitle != []} class="text-sm text-base-content/70">
+            {render_slot(@subtitle)}
+          </p>
+        </div>
+        <div class="flex-none">{render_slot(@actions)}</div>
+      </header>
+      \"\"\"
+    end
+    """
+
+    add_component_if_missing(igniter, core_components_module, :header, 1, code)
+  end
+
+  defp add_table_component(igniter, core_components_module) do
+    code = """
+    @doc \"\"\"
+    Renders a table with generic styling.
+
+    ## Examples
+
+        <.table id="users" rows={@users}>
+          <:col :let={user} label="id">{user.id}</:col>
+          <:col :let={user} label="username">{user.username}</:col>
+        </.table>
+    \"\"\"
+    attr :id, :string, required: true
+    attr :rows, :list, required: true
+    attr :row_id, :any, default: nil, doc: "the function for generating the row id"
+    attr :row_click, :any, default: nil, doc: "the function for handling phx-click on each row"
+
+    attr :row_item, :any,
+      default: &Function.identity/1,
+      doc: "the function for mapping each row before calling the :col and :action slots"
+
+    slot :col, required: true do
+      attr :label, :string
+    end
+
+    slot :action, doc: "the slot for showing user actions in the last table column"
+
+    def table(assigns) do
+      assigns =
+        with %{rows: %Phoenix.LiveView.LiveStream{}} <- assigns do
+          assign(assigns, row_id: assigns.row_id || fn {id, _item} -> id end)
+        end
+
+      ~H\"\"\"
+      <table class="table table-zebra">
+        <thead>
+          <tr>
+            <th :for={col <- @col}>{col[:label]}</th>
+            <th :if={@action != []}>
+              <span class="sr-only">{gettext("Actions")}</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody id={@id} phx-update={is_struct(@rows, Phoenix.LiveView.LiveStream) && "stream"}>
+          <tr :for={row <- @rows} id={@row_id && @row_id.(row)}>
+            <td
+              :for={col <- @col}
+              phx-click={@row_click && @row_click.(row)}
+              class={@row_click && "hover:cursor-pointer"}
+            >
+              {render_slot(col, @row_item.(row))}
+            </td>
+            <td :if={@action != []} class="w-0 font-semibold">
+              <div class="flex gap-4">
+                <%= for action <- @action do %>
+                  {render_slot(action, @row_item.(row))}
+                <% end %>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      \"\"\"
+    end
+    """
+
+    add_component_if_missing(igniter, core_components_module, :table, 1, code)
+  end
+
+  defp add_list_component(igniter, core_components_module) do
+    code = """
+    @doc \"\"\"
+    Renders a data list.
+
+    ## Examples
+
+        <.list>
+          <:item title="Title">{@post.title}</:item>
+          <:item title="Views">{@post.views}</:item>
+        </.list>
+    \"\"\"
+    slot :item, required: true do
+      attr :title, :string, required: true
+    end
+
+    def list(assigns) do
+      ~H\"\"\"
+      <ul class="list">
+        <li :for={item <- @item} class="list-row">
+          <div class="list-col-grow">
+            <div class="font-bold">{item.title}</div>
+            <div>{render_slot(item)}</div>
+          </div>
+        </li>
+      </ul>
+      \"\"\"
+    end
+    """
+
+    add_component_if_missing(igniter, core_components_module, :list, 1, code)
+  end
+
+  defp add_component_if_missing(igniter, module, function_name, arity, code) do
+    Igniter.Project.Module.find_and_update_module!(igniter, module, fn zipper ->
+      case Igniter.Code.Function.move_to_def(zipper, function_name, arity) do
+        {:ok, _} -> {:ok, zipper}
+        :error -> {:ok, Igniter.Code.Common.add_code(zipper, code)}
+      end
+    end)
+  end
+end

--- a/lib/mix/tasks/phx/install/components/tailwind.ex
+++ b/lib/mix/tasks/phx/install/components/tailwind.ex
@@ -1,0 +1,179 @@
+defmodule Mix.Tasks.Phx.Install.Components.Tailwind do
+  @shortdoc "Adds Tailwind data display components"
+  @moduledoc """
+  Adds data display components for Phoenix generators using plain Tailwind CSS.
+
+  This task adds the following components to CoreComponents:
+  - `header/1` — page header with title, subtitle, and actions
+  - `table/1` — data table with streaming support
+  - `list/1` — data list with title/content pairs
+
+  These components are required by `phx.gen.html` and `phx.gen.live`.
+
+  ## Usage
+
+      mix phx.install.components.tailwind
+
+  This task is typically composed by `mix phx.install.components` rather than directly.
+  """
+  use Igniter.Mix.Task
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _composing_task) do
+    %Igniter.Mix.Task.Info{
+      group: :phoenix,
+      example: "mix phx.install.components.tailwind"
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    web_module = Igniter.Libs.Phoenix.web_module(igniter)
+    core_components_module = Module.concat(web_module, CoreComponents)
+
+    igniter
+    |> add_header_component(core_components_module)
+    |> add_table_component(core_components_module)
+    |> add_list_component(core_components_module)
+  end
+
+  defp add_header_component(igniter, core_components_module) do
+    code = """
+    @doc \"\"\"
+    Renders a header with title.
+    \"\"\"
+    slot :inner_block, required: true
+    slot :subtitle
+    slot :actions
+
+    def header(assigns) do
+      ~H\"\"\"
+      <header class={[@actions != [] && "flex items-center justify-between gap-6", "pb-4"]}>
+        <div>
+          <h1 class="text-lg font-semibold leading-8">
+            {render_slot(@inner_block)}
+          </h1>
+          <p :if={@subtitle != []} class="text-sm text-base-content/70">
+            {render_slot(@subtitle)}
+          </p>
+        </div>
+        <div class="flex-none">{render_slot(@actions)}</div>
+      </header>
+      \"\"\"
+    end
+    """
+
+    add_component_if_missing(igniter, core_components_module, :header, 1, code)
+  end
+
+  defp add_table_component(igniter, core_components_module) do
+    code = """
+    @doc \"\"\"
+    Renders a table with generic styling.
+
+    ## Examples
+
+        <.table id="users" rows={@users}>
+          <:col :let={user} label="id">{user.id}</:col>
+          <:col :let={user} label="username">{user.username}</:col>
+        </.table>
+    \"\"\"
+    attr :id, :string, required: true
+    attr :rows, :list, required: true
+    attr :row_id, :any, default: nil, doc: "the function for generating the row id"
+    attr :row_click, :any, default: nil, doc: "the function for handling phx-click on each row"
+
+    attr :row_item, :any,
+      default: &Function.identity/1,
+      doc: "the function for mapping each row before calling the :col and :action slots"
+
+    slot :col, required: true do
+      attr :label, :string
+    end
+
+    slot :action, doc: "the slot for showing user actions in the last table column"
+
+    def table(assigns) do
+      assigns =
+        with %{rows: %Phoenix.LiveView.LiveStream{}} <- assigns do
+          assign(assigns, row_id: assigns.row_id || fn {id, _item} -> id end)
+        end
+
+      ~H\"\"\"
+      <table class="table table-zebra">
+        <thead>
+          <tr>
+            <th :for={col <- @col}>{col[:label]}</th>
+            <th :if={@action != []}>
+              <span class="sr-only">Actions</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody id={@id} phx-update={is_struct(@rows, Phoenix.LiveView.LiveStream) && "stream"}>
+          <tr :for={row <- @rows} id={@row_id && @row_id.(row)}>
+            <td
+              :for={col <- @col}
+              phx-click={@row_click && @row_click.(row)}
+              class={@row_click && "hover:cursor-pointer"}
+            >
+              {render_slot(col, @row_item.(row))}
+            </td>
+            <td :if={@action != []} class="w-0 font-semibold">
+              <div class="flex gap-4">
+                <%= for action <- @action do %>
+                  {render_slot(action, @row_item.(row))}
+                <% end %>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      \"\"\"
+    end
+    """
+
+    add_component_if_missing(igniter, core_components_module, :table, 1, code)
+  end
+
+  defp add_list_component(igniter, core_components_module) do
+    code = """
+    @doc \"\"\"
+    Renders a data list.
+
+    ## Examples
+
+        <.list>
+          <:item title="Title">{@post.title}</:item>
+          <:item title="Views">{@post.views}</:item>
+        </.list>
+    \"\"\"
+    slot :item, required: true do
+      attr :title, :string, required: true
+    end
+
+    def list(assigns) do
+      ~H\"\"\"
+      <ul class="list">
+        <li :for={item <- @item} class="list-row">
+          <div class="list-col-grow">
+            <div class="font-bold">{item.title}</div>
+            <div>{render_slot(item)}</div>
+          </div>
+        </li>
+      </ul>
+      \"\"\"
+    end
+    """
+
+    add_component_if_missing(igniter, core_components_module, :list, 1, code)
+  end
+
+  defp add_component_if_missing(igniter, module, function_name, arity, code) do
+    Igniter.Project.Module.find_and_update_module!(igniter, module, fn zipper ->
+      case Igniter.Code.Function.move_to_def(zipper, function_name, arity) do
+        {:ok, _} -> {:ok, zipper}
+        :error -> {:ok, Igniter.Code.Common.add_code(zipper, code)}
+      end
+    end)
+  end
+end

--- a/lib/mix/tasks/phx/install/heroicons.ex
+++ b/lib/mix/tasks/phx/install/heroicons.ex
@@ -54,7 +54,8 @@ defmodule Mix.Tasks.Phx.Install.Heroicons do
        depth: 1}
     )
     |> create_heroicons_js()
-    |> append_plugin_to_app_css()
+    |> create_heroicons_css()
+    |> PhxInstall.append_css_import(~s|@import "./phx-heroicons.css";|)
     |> add_icon_component(web_module)
   end
 
@@ -64,31 +65,10 @@ defmodule Mix.Tasks.Phx.Install.Heroicons do
     )
   end
 
-  defp append_plugin_to_app_css(igniter) do
-    path = "assets/css/app.css"
-    plugin_line = ~s|@plugin "../vendor/heroicons";|
+  defp create_heroicons_css(igniter) do
+    content = ~s|@plugin "../vendor/heroicons";\n|
 
-    case Rewrite.source(igniter.rewrite, path) do
-      {:ok, source} ->
-        content = Rewrite.Source.get(source, :content)
-
-        if String.contains?(content, plugin_line) do
-          igniter
-        else
-          updated_content =
-            String.replace(
-              content,
-              ~s|@import "tailwindcss";|,
-              ~s|@import "tailwindcss";\n#{plugin_line}|
-            )
-
-          updated_source = Rewrite.Source.update(source, :content, updated_content)
-          %{igniter | rewrite: Rewrite.update!(igniter.rewrite, updated_source)}
-        end
-
-      {:error, _} ->
-        igniter
-    end
+    Igniter.create_new_file(igniter, "assets/css/phx-heroicons.css", content, on_exists: :skip)
   end
 
   defp add_icon_component(igniter, web_module) do

--- a/lib/mix/tasks/phx/install/html.ex
+++ b/lib/mix/tasks/phx/install/html.ex
@@ -3,29 +3,47 @@ defmodule Mix.Tasks.Phx.Install.Html do
   @moduledoc """
   Adds HTML rendering support to a Phoenix application.
 
-  This task sets up:
+  This is an orchestrator that sets up shared HTML infrastructure
+  and then delegates to a UI-variant-specific task for components,
+  layouts, and templates.
+
+  ## Shared infrastructure (always installed)
+
   - `phoenix_html` dependency
-  - `lib/<app>_web/components/core_components.ex` - Core UI components
-  - `lib/<app>_web/components/layouts.ex` - Layout component module
-  - `lib/<app>_web/components/layouts/root.html.heex` - Root HTML layout
-  - `lib/<app>_web/components/layouts/app.html.heex` - App layout
-  - `lib/<app>_web/controllers/error_html.ex` - HTML error rendering
-  - Updates web module with `html` and `html_helpers` functions
+  - `lib/<app>_web/controllers/error_html.ex` — HTML error rendering
+  - Web module `html/0` and `html_helpers/0` functions
+  - Browser pipeline in router
+
+  ## Variant-specific (based on `--ui`)
+
+  - `phx.install.html.daisy` — DaisyUI components and layouts (default)
+  - `phx.install.html.tailwind` — plain Tailwind CSS components and layouts
 
   ## Usage
 
       mix phx.install.html
+      mix phx.install.html --ui tailwind
+
+  ## Options
+
+  - `--ui` — UI component library: "daisy" (default) or "tailwind"
 
   This task is typically called by `mix phx.install` rather than directly.
   """
   use Igniter.Mix.Task
 
   @impl Igniter.Mix.Task
-  def info(_argv, _composing_task) do
+  def info(argv, _composing_task) do
+    {parsed, _, _} = OptionParser.parse(argv, strict: [ui: :string])
+    ui = Keyword.get(parsed, :ui, "daisy")
+
     %Igniter.Mix.Task.Info{
       group: :phoenix,
       example: "mix phx.install.html",
-      adds_deps: [{:phoenix_html, "~> 4.1"}]
+      adds_deps: [{:phoenix_html, "~> 4.1"}],
+      schema: [ui: :string],
+      defaults: [ui: "daisy"],
+      composes: ["phx.install.html.#{ui}"]
     }
   end
 
@@ -35,374 +53,18 @@ defmodule Mix.Tasks.Phx.Install.Html do
     web_module = Igniter.Libs.Phoenix.web_module(igniter)
     endpoint_module = Module.concat(web_module, Endpoint)
 
+    opts = igniter.args.options
+    ui = opts[:ui] || "daisy"
+
     igniter
     |> Igniter.Project.Deps.add_dep({:phoenix, "~> 1.7"})
     |> Igniter.Project.Deps.add_dep({:phoenix_html, "~> 4.1"})
     |> Igniter.Project.IgniterConfig.add_extension(Igniter.Extensions.Phoenix)
-    |> create_core_components(web_module)
-    |> create_layouts_module(web_module)
-    |> create_root_layout(web_module)
-    |> create_app_layout(web_module)
-    |> create_error_html(web_module)
     |> add_html_helpers_to_web_module(web_module, endpoint_module)
     |> add_browser_pipeline_to_router(web_module)
     |> update_endpoint_error_config(app_name, endpoint_module, web_module)
-  end
-
-  defp create_core_components(igniter, web_module) do
-    core_components_module = Module.concat(web_module, CoreComponents)
-
-    Igniter.Project.Module.find_and_update_or_create_module(
-      igniter,
-      core_components_module,
-      """
-      @moduledoc \"\"\"
-      Provides core UI components.
-
-      The components in this module use function components and can be used
-      in both regular views and LiveView.
-      \"\"\"
-
-      use Phoenix.Component
-
-      @doc \"\"\"
-      Renders flash notices.
-
-      ## Examples
-
-          <.flash kind={:info} flash={@flash} />
-      \"\"\"
-      attr :id, :string, doc: "the optional id of flash container"
-      attr :flash, :map, default: %{}, doc: "the map of flash messages to display"
-      attr :title, :string, default: nil
-      attr :kind, :atom, values: [:info, :error], doc: "used for styling and flash lookup"
-      attr :rest, :global, doc: "the arbitrary HTML attributes to add to the flash container"
-
-      slot :inner_block, doc: "the optional inner block that renders the flash message"
-
-      def flash(assigns) do
-        assigns = assign_new(assigns, :id, fn -> "flash-\#{assigns.kind}" end)
-
-        ~H\"\"\"
-        <div
-          :if={msg = render_slot(@inner_block) || Phoenix.Flash.get(@flash, @kind)}
-          id={@id}
-          role="alert"
-          class={"flash flash-\#{@kind}"}
-          {@rest}
-        >
-          <p :if={@title} class="flash-title">{@title}</p>
-          <p class="flash-message">{msg}</p>
-        </div>
-        \"\"\"
-      end
-
-      @doc \"\"\"
-      Shows the flash group with standard titles and content.
-
-      ## Examples
-
-          <.flash_group flash={@flash} />
-      \"\"\"
-      attr :flash, :map, required: true, doc: "the map of flash messages"
-      attr :id, :string, default: "flash-group", doc: "the optional id of flash container"
-
-      def flash_group(assigns) do
-        ~H\"\"\"
-        <div id={@id}>
-          <.flash kind={:info} flash={@flash} />
-          <.flash kind={:error} flash={@flash} />
-        </div>
-        \"\"\"
-      end
-
-      @doc \"\"\"
-      Renders a simple form.
-
-      ## Examples
-
-          <.simple_form for={@form} phx-change="validate" phx-submit="save">
-            <.input field={@form[:email]} label="Email"/>
-            <:actions>
-              <.button>Save</.button>
-            </:actions>
-          </.simple_form>
-      \"\"\"
-      attr :for, :any, required: true, doc: "the data structure for the form"
-      attr :as, :any, default: nil, doc: "the server side parameter to collect all input under"
-
-      attr :rest, :global,
-        include: ~w(autocomplete name rel action enctype method novalidate target multipart),
-        doc: "the arbitrary HTML attributes to apply to the form tag"
-
-      slot :inner_block, required: true
-      slot :actions, doc: "the slot for form actions, such as a submit button"
-
-      def simple_form(assigns) do
-        ~H\"\"\"
-        <.form :let={f} for={@for} as={@as} {@rest}>
-          {render_slot(@inner_block, f)}
-          <div :for={action <- @actions}>
-            {render_slot(action, f)}
-          </div>
-        </.form>
-        \"\"\"
-      end
-
-      @doc \"\"\"
-      Renders a button with navigation support.
-
-      ## Examples
-
-          <.button>Send!</.button>
-          <.button phx-click="go" variant="primary">Send!</.button>
-          <.button navigate={~p"/"}>Home</.button>
-      \"\"\"
-      attr :rest, :global, include: ~w(href navigate patch method download name value disabled form)
-      attr :class, :any
-      attr :variant, :string, values: ~w(primary)
-      slot :inner_block, required: true
-
-      def button(%{rest: rest} = assigns) do
-        variants = %{"primary" => "button-primary", nil => "button"}
-
-        assigns =
-          assign_new(assigns, :class, fn ->
-            [Map.fetch!(variants, assigns[:variant])]
-          end)
-
-        if rest[:href] || rest[:navigate] || rest[:patch] do
-          ~H\"\"\"
-          <.link class={@class} {@rest}>
-            {render_slot(@inner_block)}
-          </.link>
-          \"\"\"
-        else
-          ~H\"\"\"
-          <button class={@class} {@rest}>
-            {render_slot(@inner_block)}
-          </button>
-          \"\"\"
-        end
-      end
-
-      @doc \"\"\"
-      Renders an input with label and error messages.
-
-      A `Phoenix.HTML.FormField` may be passed as argument,
-      which is used to retrieve the input name, id, and values.
-      Otherwise all attributes may be passed explicitly.
-
-      ## Examples
-
-          <.input field={@form[:email]} type="email" />
-          <.input name="my-input" errors={["oh no!"]} />
-      \"\"\"
-      attr :id, :any, default: nil
-      attr :name, :any
-      attr :label, :string, default: nil
-      attr :value, :any
-
-      attr :type, :string,
-        default: "text",
-        values: ~w(checkbox color date datetime-local email file hidden month number password
-                   range search select tel text textarea time url week)
-
-      attr :field, Phoenix.HTML.FormField,
-        doc: "a form field struct retrieved from the form, for example: @form[:email]"
-
-      attr :errors, :list, default: []
-      attr :checked, :boolean, doc: "the checked flag for checkbox inputs"
-      attr :prompt, :string, default: nil, doc: "the prompt for select inputs"
-      attr :options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2"
-      attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
-
-      attr :rest, :global,
-        include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
-                    multiple pattern placeholder readonly required rows size step)
-
-      def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
-        errors = if Phoenix.Component.used_input?(field), do: field.errors, else: []
-
-        assigns
-        |> assign(field: nil, id: assigns.id || field.id)
-        |> assign(:errors, Enum.map(errors, &translate_error(&1)))
-        |> assign_new(:name, fn -> if assigns.multiple, do: field.name <> "[]", else: field.name end)
-        |> assign_new(:value, fn -> field.value end)
-        |> input()
-      end
-
-      def input(%{type: "checkbox"} = assigns) do
-        assigns =
-          assign_new(assigns, :checked, fn ->
-            Phoenix.HTML.Form.normalize_value("checkbox", assigns[:value])
-          end)
-
-        ~H\"\"\"
-        <div>
-          <label>
-            <input type="hidden" name={@name} value="false" disabled={@rest[:disabled]} />
-            <input
-              type="checkbox"
-              id={@id}
-              name={@name}
-              value="true"
-              checked={@checked}
-              {@rest}
-            />
-            {@label}
-          </label>
-          <.error :for={msg <- @errors}>{msg}</.error>
-        </div>
-        \"\"\"
-      end
-
-      def input(%{type: "select"} = assigns) do
-        ~H\"\"\"
-        <div>
-          <label :if={@label}>{@label}</label>
-          <select id={@id} name={@name} multiple={@multiple} {@rest}>
-            <option :if={@prompt} value="">{@prompt}</option>
-            {Phoenix.HTML.Form.options_for_select(@options, @value)}
-          </select>
-          <.error :for={msg <- @errors}>{msg}</.error>
-        </div>
-        \"\"\"
-      end
-
-      def input(%{type: "textarea"} = assigns) do
-        ~H\"\"\"
-        <div>
-          <label :if={@label}>{@label}</label>
-          <textarea id={@id} name={@name} {@rest}>{Phoenix.HTML.Form.normalize_value("textarea", @value)}</textarea>
-          <.error :for={msg <- @errors}>{msg}</.error>
-        </div>
-        \"\"\"
-      end
-
-      def input(%{type: "hidden"} = assigns) do
-        ~H\"\"\"
-        <input type="hidden" id={@id} name={@name} value={@value} {@rest} />
-        \"\"\"
-      end
-
-      def input(assigns) do
-        ~H\"\"\"
-        <div>
-          <label :if={@label}>{@label}</label>
-          <input
-            type={@type}
-            name={@name}
-            id={@id}
-            value={Phoenix.HTML.Form.normalize_value(@type, @value)}
-            {@rest}
-          />
-          <.error :for={msg <- @errors}>{msg}</.error>
-        </div>
-        \"\"\"
-      end
-
-      defp error(assigns) do
-        ~H\"\"\"
-        <p class="error">{render_slot(@inner_block)}</p>
-        \"\"\"
-      end
-
-      @doc \"\"\"
-      Translates an error message.
-      \"\"\"
-      def translate_error({msg, opts}) do
-        Enum.reduce(opts, msg, fn {key, value}, acc ->
-          String.replace(acc, "%{\#{key}}", fn _ -> to_string(value) end)
-        end)
-      end
-
-      @doc \"\"\"
-      Translates the errors for a field from a keyword list of errors.
-      \"\"\"
-      def translate_errors(errors, field) when is_list(errors) do
-        for {^field, {msg, opts}} <- errors, do: translate_error({msg, opts})
-      end
-      """,
-      fn zipper -> {:ok, zipper} end
-    )
-  end
-
-  defp create_layouts_module(igniter, web_module) do
-    layouts_module = Module.concat(web_module, Layouts)
-
-    Igniter.Project.Module.find_and_update_or_create_module(
-      igniter,
-      layouts_module,
-      """
-      @moduledoc \"\"\"
-      This module holds different layouts used by your application.
-
-      See the `layouts` directory for all templates available.
-      \"\"\"
-      use #{inspect(web_module)}, :html
-
-      embed_templates "layouts/*"
-      """,
-      fn zipper -> {:ok, zipper} end
-    )
-  end
-
-  defp create_root_layout(igniter, web_module) do
-    app_module =
-      web_module
-      |> Module.split()
-      |> List.first()
-      |> then(fn name -> String.replace(name, "Web", "") end)
-
-    layout_content = """
-    <!DOCTYPE html>
-    <html lang="en">
-      <head>
-        <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="csrf-token" content={get_csrf_token()} />
-        <.live_title default="#{app_module}">
-          {assigns[:page_title]}
-        </.live_title>
-        <link phx-track-static rel="stylesheet" href={~p"/assets/css/app.css"} />
-        <script defer phx-track-static type="text/javascript" src={~p"/assets/js/app.js"}>
-        </script>
-      </head>
-      <body>
-        {@inner_content}
-      </body>
-    </html>
-    """
-
-    web_module_snake =
-      web_module
-      |> Module.split()
-      |> List.last()
-      |> Macro.underscore()
-
-    path = "lib/#{web_module_snake}/components/layouts/root.html.heex"
-
-    Igniter.create_new_file(igniter, path, layout_content, on_exists: :skip)
-  end
-
-  defp create_app_layout(igniter, web_module) do
-    layout_content = """
-    <main class="container">
-      <.flash_group flash={@flash} />
-      {@inner_content}
-    </main>
-    """
-
-    web_module_snake =
-      web_module
-      |> Module.split()
-      |> List.last()
-      |> Macro.underscore()
-
-    path = "lib/#{web_module_snake}/components/layouts/app.html.heex"
-
-    Igniter.create_new_file(igniter, path, layout_content, on_exists: :skip)
+    |> create_error_html(web_module)
+    |> Igniter.compose_task("phx.install.html.#{ui}")
   end
 
   defp create_error_html(igniter, web_module) do
@@ -419,7 +81,7 @@ defmodule Mix.Tasks.Phx.Install.Html do
       \"\"\"
       use #{inspect(web_module)}, :html
 
-      # If you want to customize your error pages,
+      # If you want to customise your error pages,
       # uncomment the embed_templates/1 call below
       # and add pages to the error directory:
       #

--- a/lib/mix/tasks/phx/install/html/daisy.ex
+++ b/lib/mix/tasks/phx/install/html/daisy.ex
@@ -1,0 +1,755 @@
+defmodule Mix.Tasks.Phx.Install.Html.Daisy do
+  @shortdoc "Adds DaisyUI HTML components"
+  @moduledoc """
+  Adds DaisyUI core components, layouts, and templates.
+
+  This task creates:
+  - CoreComponents module with DaisyUI-styled flash, button, input, simple_form
+  - Layouts module with inline `app/1`, `flash_group/1`, and `theme_toggle/1`
+  - Root HTML layout with theme-switching JavaScript
+  - DaisyUI CSS configuration (`assets/css/phx-daisy.css`)
+  - DaisyUI vendor JS files (`assets/vendor/daisyui.js`, `assets/vendor/daisyui-theme.js`)
+  - Phoenix logo SVG (`priv/static/images/logo.svg`)
+
+  ## Usage
+
+      mix phx.install.html.daisy
+
+  This task is typically composed by `mix phx.install.html` rather than called directly.
+  """
+  use Igniter.Mix.Task
+
+  @daisyui_version "5.5.19"
+  @daisyui_base_url "https://github.com/saadeghi/daisyui/releases/download/v#{@daisyui_version}"
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _composing_task) do
+    %Igniter.Mix.Task.Info{
+      group: :phoenix,
+      example: "mix phx.install.html.daisy"
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    web_module = Igniter.Libs.Phoenix.web_module(igniter)
+
+    igniter
+    |> create_core_components(web_module)
+    |> create_layouts_module(web_module)
+    |> create_root_layout(web_module)
+    |> create_logo_svg()
+    |> create_daisy_css()
+    |> PhxInstall.append_css_import(~s|@import "./phx-daisy.css";|)
+    |> download_vendor_file("daisyui.js")
+    |> download_vendor_file("daisyui-theme.js")
+  end
+
+  defp create_core_components(igniter, web_module) do
+    core_components_module = Module.concat(web_module, CoreComponents)
+    gettext_module = Module.concat(web_module, Gettext)
+
+    Igniter.Project.Module.find_and_update_or_create_module(
+      igniter,
+      core_components_module,
+      core_components_code(gettext_module),
+      fn zipper -> {:ok, zipper} end
+    )
+  end
+
+  defp core_components_code(gettext_module) do
+    """
+    @moduledoc \"\"\"
+    Provides core UI components.
+
+    The foundation for styling is Tailwind CSS, a utility-first CSS framework,
+    augmented with daisyUI, a Tailwind CSS plugin that provides UI components
+    and themes. Here are useful references:
+
+      * [daisyUI](https://daisyui.com/docs/intro/) - a good place to get
+        started and see the available components.
+
+      * [Tailwind CSS](https://tailwindcss.com) - the foundational framework
+        we build on. You will use it for layout, sizing, flexbox, grid, and
+        spacing.
+
+      * [Heroicons](https://heroicons.com) - see `icon/1` for usage.
+
+      * [Phoenix.Component](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html) -
+        the component system used by Phoenix. Some components, such as `<.link>`
+        and `<.form>`, are defined there.
+
+    \"\"\"
+    use Phoenix.Component
+    use Gettext, backend: #{inspect(gettext_module)}
+
+    @doc \"\"\"
+    Renders flash notices.
+
+    ## Examples
+
+        <.flash kind={:info} flash={@flash} />
+        <.flash kind={:info} phx-mounted={show("#flash")}>Welcome Back!</.flash>
+    \"\"\"
+    attr :id, :string, doc: "the optional id of flash container"
+    attr :flash, :map, default: %{}, doc: "the map of flash messages to display"
+    attr :title, :string, default: nil
+    attr :kind, :atom, values: [:info, :error], doc: "used for styling and flash lookup"
+    attr :rest, :global, doc: "the arbitrary HTML attributes to add to the flash container"
+
+    slot :inner_block, doc: "the optional inner block that renders the flash message"
+
+    def flash(assigns) do
+      assigns = assign_new(assigns, :id, fn -> "flash-\#{assigns.kind}" end)
+
+      ~H\"\"\"
+      <div
+        :if={msg = render_slot(@inner_block) || Phoenix.Flash.get(@flash, @kind)}
+        id={@id}
+        phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide("#\#{@id}")}
+        role="alert"
+        class="toast toast-top toast-end z-50"
+        {@rest}
+      >
+        <div class={[
+          "alert w-80 sm:w-96 max-w-80 sm:max-w-96 text-wrap",
+          @kind == :info && "alert-info",
+          @kind == :error && "alert-error"
+        ]}>
+          <.icon :if={@kind == :info} name="hero-information-circle" class="size-5 shrink-0" />
+          <.icon :if={@kind == :error} name="hero-exclamation-circle" class="size-5 shrink-0" />
+          <div>
+            <p :if={@title} class="font-semibold">{@title}</p>
+            <p>{msg}</p>
+          </div>
+          <div class="flex-1" />
+          <button type="button" class="group self-start cursor-pointer" aria-label={gettext("close")}>
+            <.icon name="hero-x-mark" class="size-5 opacity-40 group-hover:opacity-70" />
+          </button>
+        </div>
+      </div>
+      \"\"\"
+    end
+
+    @doc \"\"\"
+    Renders a button with navigation support.
+
+    ## Examples
+
+        <.button>Send!</.button>
+        <.button phx-click="go" variant="primary">Send!</.button>
+        <.button navigate={~p"/"}>Home</.button>
+    \"\"\"
+    attr :rest, :global, include: ~w(href navigate patch method download name value disabled)
+    attr :class, :any
+    attr :variant, :string, values: ~w(primary)
+    slot :inner_block, required: true
+
+    def button(%{rest: rest} = assigns) do
+      variants = %{"primary" => "btn-primary", nil => "btn-primary btn-soft"}
+
+      assigns =
+        assign_new(assigns, :class, fn ->
+          ["btn", Map.fetch!(variants, assigns[:variant])]
+        end)
+
+      if rest[:href] || rest[:navigate] || rest[:patch] do
+        ~H\"\"\"
+        <.link class={@class} {@rest}>
+          {render_slot(@inner_block)}
+        </.link>
+        \"\"\"
+      else
+        ~H\"\"\"
+        <button class={@class} {@rest}>
+          {render_slot(@inner_block)}
+        </button>
+        \"\"\"
+      end
+    end
+
+    @doc \"\"\"
+    Renders an input with label and error messages.
+
+    A `Phoenix.HTML.FormField` may be passed as argument,
+    which is used to retrieve the input name, id, and values.
+    Otherwise all attributes may be passed explicitly.
+
+    ## Examples
+
+        <.input field={@form[:email]} type="email" />
+        <.input name="my-input" errors={["oh no!"]} />
+    \"\"\"
+    attr :id, :any, default: nil
+    attr :name, :any
+    attr :label, :string, default: nil
+    attr :value, :any
+
+    attr :type, :string,
+      default: "text",
+      values: ~w(checkbox color date datetime-local email file month number password
+                 search select tel text textarea time url week hidden)
+
+    attr :field, Phoenix.HTML.FormField,
+      doc: "a form field struct retrieved from the form, for example: @form[:email]"
+
+    attr :errors, :list, default: []
+    attr :checked, :boolean, doc: "the checked flag for checkbox inputs"
+    attr :prompt, :string, default: nil, doc: "the prompt for select inputs"
+    attr :options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2"
+    attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
+    attr :class, :any, default: nil, doc: "the input class to use over defaults"
+    attr :error_class, :any, default: nil, doc: "the input error class to use over defaults"
+
+    attr :rest, :global,
+      include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
+                  multiple pattern placeholder readonly required rows size step)
+
+    def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
+      errors = if Phoenix.Component.used_input?(field), do: field.errors, else: []
+
+      assigns
+      |> assign(field: nil, id: assigns.id || field.id)
+      |> assign(:errors, Enum.map(errors, &translate_error(&1)))
+      |> assign_new(:name, fn -> if assigns.multiple, do: field.name <> "[]", else: field.name end)
+      |> assign_new(:value, fn -> field.value end)
+      |> input()
+    end
+
+    def input(%{type: "hidden"} = assigns) do
+      ~H\"\"\"
+      <input type="hidden" id={@id} name={@name} value={@value} {@rest} />
+      \"\"\"
+    end
+
+    def input(%{type: "checkbox"} = assigns) do
+      assigns =
+        assign_new(assigns, :checked, fn ->
+          Phoenix.HTML.Form.normalize_value("checkbox", assigns[:value])
+        end)
+
+      ~H\"\"\"
+      <div class="fieldset mb-2">
+        <label for={@id}>
+          <input
+            type="hidden"
+            name={@name}
+            value="false"
+            disabled={@rest[:disabled]}
+            form={@rest[:form]}
+          />
+          <span class="label">
+            <input
+              type="checkbox"
+              id={@id}
+              name={@name}
+              value="true"
+              checked={@checked}
+              class={@class || "checkbox checkbox-sm"}
+              {@rest}
+            />{@label}
+          </span>
+        </label>
+        <.error :for={msg <- @errors}>{msg}</.error>
+      </div>
+      \"\"\"
+    end
+
+    def input(%{type: "select"} = assigns) do
+      ~H\"\"\"
+      <div class="fieldset mb-2">
+        <label for={@id}>
+          <span :if={@label} class="label mb-1">{@label}</span>
+          <select
+            id={@id}
+            name={@name}
+            class={[@class || "w-full select", @errors != [] && (@error_class || "select-error")]}
+            multiple={@multiple}
+            {@rest}
+          >
+            <option :if={@prompt} value="">{@prompt}</option>
+            {Phoenix.HTML.Form.options_for_select(@options, @value)}
+          </select>
+        </label>
+        <.error :for={msg <- @errors}>{msg}</.error>
+      </div>
+      \"\"\"
+    end
+
+    def input(%{type: "textarea"} = assigns) do
+      ~H\"\"\"
+      <div class="fieldset mb-2">
+        <label for={@id}>
+          <span :if={@label} class="label mb-1">{@label}</span>
+          <textarea
+            id={@id}
+            name={@name}
+            class={[
+              @class || "w-full textarea",
+              @errors != [] && (@error_class || "textarea-error")
+            ]}
+            {@rest}
+          >{Phoenix.HTML.Form.normalize_value("textarea", @value)}</textarea>
+        </label>
+        <.error :for={msg <- @errors}>{msg}</.error>
+      </div>
+      \"\"\"
+    end
+
+    def input(assigns) do
+      ~H\"\"\"
+      <div class="fieldset mb-2">
+        <label for={@id}>
+          <span :if={@label} class="label mb-1">{@label}</span>
+          <input
+            type={@type}
+            name={@name}
+            id={@id}
+            value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+            class={[
+              @class || "w-full input",
+              @errors != [] && (@error_class || "input-error")
+            ]}
+            {@rest}
+          />
+        </label>
+        <.error :for={msg <- @errors}>{msg}</.error>
+      </div>
+      \"\"\"
+    end
+
+    @doc \"\"\"
+    Renders a simple form.
+
+    ## Examples
+
+        <.simple_form for={@form} phx-change="validate" phx-submit="save">
+          <.input field={@form[:email]} label="Email"/>
+          <:actions>
+            <.button>Save</.button>
+          </:actions>
+        </.simple_form>
+    \"\"\"
+    attr :for, :any, required: true, doc: "the data structure for the form"
+    attr :as, :any, default: nil, doc: "the server side parameter to collect all input under"
+
+    attr :rest, :global,
+      include: ~w(autocomplete name rel action enctype method novalidate target multipart),
+      doc: "the arbitrary HTML attributes to apply to the form tag"
+
+    slot :inner_block, required: true
+    slot :actions, doc: "the slot for form actions, such as a submit button"
+
+    def simple_form(assigns) do
+      ~H\"\"\"
+      <.form :let={f} for={@for} as={@as} {@rest}>
+        {render_slot(@inner_block, f)}
+        <div :for={action <- @actions}>
+          {render_slot(action, f)}
+        </div>
+      </.form>
+      \"\"\"
+    end
+
+    defp error(assigns) do
+      ~H\"\"\"
+      <p class="mt-1.5 flex gap-2 items-center text-sm text-error">
+        <.icon name="hero-exclamation-circle" class="size-5" />
+        {render_slot(@inner_block)}
+      </p>
+      \"\"\"
+    end
+
+    @doc \"\"\"
+    Translates an error message using gettext.
+    \"\"\"
+    def translate_error({msg, opts}) do
+      if count = opts[:count] do
+        Gettext.dngettext(#{inspect(gettext_module)}, "errors", msg, msg, count, opts)
+      else
+        Gettext.dgettext(#{inspect(gettext_module)}, "errors", msg, opts)
+      end
+    end
+
+    @doc \"\"\"
+    Translates the errors for a field from a keyword list of errors.
+    \"\"\"
+    def translate_errors(errors, field) when is_list(errors) do
+      for {^field, {msg, opts}} <- errors, do: translate_error({msg, opts})
+    end
+    """
+  end
+
+  defp create_layouts_module(igniter, web_module) do
+    layouts_module = Module.concat(web_module, Layouts)
+
+    Igniter.Project.Module.find_and_update_or_create_module(
+      igniter,
+      layouts_module,
+      layouts_code(web_module),
+      fn zipper -> {:ok, zipper} end
+    )
+  end
+
+  defp layouts_code(web_module) do
+    """
+    @moduledoc \"\"\"
+    This module holds layouts and related functionality
+    used by your application.
+    \"\"\"
+    use #{inspect(web_module)}, :html
+
+    embed_templates "layouts/*"
+
+    @doc \"\"\"
+    Renders your app layout.
+    \"\"\"
+    attr :flash, :map, required: true, doc: "the map of flash messages"
+
+    attr :current_scope, :map,
+      default: nil,
+      doc: "the current scope"
+
+    slot :inner_block, required: true
+
+    def app(assigns) do
+      ~H\"\"\"
+      <header class="navbar px-4 sm:px-6 lg:px-8">
+        <div class="flex-1">
+          <a href="/" class="flex-1 flex w-fit items-center gap-2">
+            <img src={~p"/images/logo.svg"} width="36" />
+            <span class="text-sm font-semibold">v{Application.spec(:phoenix, :vsn)}</span>
+          </a>
+        </div>
+        <div class="flex-none">
+          <ul class="flex flex-column px-1 space-x-4 items-center">
+            <li>
+              <a href="https://phoenixframework.org/" class="btn btn-ghost">Website</a>
+            </li>
+            <li>
+              <a href="https://github.com/phoenixframework/phoenix" class="btn btn-ghost">GitHub</a>
+            </li>
+            <li>
+              <.theme_toggle />
+            </li>
+            <li>
+              <a href="https://hexdocs.pm/phoenix/overview.html" class="btn btn-primary">
+                Get Started <span aria-hidden="true">&rarr;</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </header>
+
+      <main class="px-4 py-20 sm:px-6 lg:px-8">
+        <div class="mx-auto max-w-2xl space-y-4">
+          {render_slot(@inner_block)}
+        </div>
+      </main>
+
+      <.flash_group flash={@flash} />
+      \"\"\"
+    end
+
+    @doc \"\"\"
+    Shows the flash group with standard titles and content.
+
+    ## Examples
+
+        <.flash_group flash={@flash} />
+    \"\"\"
+    attr :flash, :map, required: true, doc: "the map of flash messages"
+    attr :id, :string, default: "flash-group", doc: "the optional id of flash container"
+
+    def flash_group(assigns) do
+      ~H\"\"\"
+      <div id={@id} aria-live="polite">
+        <.flash kind={:info} flash={@flash} />
+        <.flash kind={:error} flash={@flash} />
+
+        <.flash
+          id="client-error"
+          kind={:error}
+          title={gettext("We can't find the internet")}
+          phx-disconnected={show(".phx-client-error #client-error") |> JS.remove_attribute("hidden")}
+          phx-connected={hide("#client-error") |> JS.set_attribute({"hidden", ""})}
+          hidden
+        >
+          {gettext("Attempting to reconnect")}
+          <.icon name="hero-arrow-path" class="ml-1 size-3 motion-safe:animate-spin" />
+        </.flash>
+
+        <.flash
+          id="server-error"
+          kind={:error}
+          title={gettext("Something went wrong!")}
+          phx-disconnected={show(".phx-server-error #server-error") |> JS.remove_attribute("hidden")}
+          phx-connected={hide("#server-error") |> JS.set_attribute({"hidden", ""})}
+          hidden
+        >
+          {gettext("Attempting to reconnect")}
+          <.icon name="hero-arrow-path" class="ml-1 size-3 motion-safe:animate-spin" />
+        </.flash>
+      </div>
+      \"\"\"
+    end
+
+    @doc \"\"\"
+    Provides dark vs light theme toggle based on themes defined in app.css.
+
+    See <head> in root.html.heex which applies the theme before page load.
+    \"\"\"
+    def theme_toggle(assigns) do
+      ~H\"\"\"
+      <div class="card relative flex flex-row items-center border-2 border-base-300 bg-base-300 rounded-full">
+        <div class="absolute w-1/3 h-full rounded-full border-1 border-base-200 bg-base-100 brightness-200 left-0 [[data-theme=light]_&]:left-1/3 [[data-theme=dark]_&]:left-2/3 transition-[left]" />
+
+        <button
+          class="flex p-2 cursor-pointer w-1/3"
+          phx-click={JS.dispatch("phx:set-theme")}
+          data-phx-theme="system"
+        >
+          <.icon name="hero-computer-desktop-micro" class="size-4 opacity-75 hover:opacity-100" />
+        </button>
+
+        <button
+          class="flex p-2 cursor-pointer w-1/3"
+          phx-click={JS.dispatch("phx:set-theme")}
+          data-phx-theme="light"
+        >
+          <.icon name="hero-sun-micro" class="size-4 opacity-75 hover:opacity-100" />
+        </button>
+
+        <button
+          class="flex p-2 cursor-pointer w-1/3"
+          phx-click={JS.dispatch("phx:set-theme")}
+          data-phx-theme="dark"
+        >
+          <.icon name="hero-moon-micro" class="size-4 opacity-75 hover:opacity-100" />
+        </button>
+      </div>
+      \"\"\"
+    end
+    """
+  end
+
+  defp create_root_layout(igniter, web_module) do
+    app_module =
+      web_module
+      |> Module.split()
+      |> List.first()
+      |> then(fn name -> String.replace(name, "Web", "") end)
+
+    layout_content = """
+    <!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="csrf-token" content={get_csrf_token()} />
+        <.live_title default="#{app_module}" suffix=" · Phoenix Framework">
+          {assigns[:page_title]}
+        </.live_title>
+        <link phx-track-static rel="stylesheet" href={~p"/assets/css/app.css"} />
+        <script defer phx-track-static type="text/javascript" src={~p"/assets/js/app.js"}>
+        </script>
+        <script>
+          (() => {
+            const setTheme = (theme) => {
+              if (theme === "system") {
+                localStorage.removeItem("phx:theme");
+                document.documentElement.removeAttribute("data-theme");
+              } else {
+                localStorage.setItem("phx:theme", theme);
+                document.documentElement.setAttribute("data-theme", theme);
+              }
+            };
+            if (!document.documentElement.hasAttribute("data-theme")) {
+              setTheme(localStorage.getItem("phx:theme") || "system");
+            }
+            window.addEventListener("storage", (e) => e.key === "phx:theme" && setTheme(e.newValue || "system"));
+            window.addEventListener("phx:set-theme", (e) => setTheme(e.target.dataset.phxTheme));
+          })();
+        </script>
+      </head>
+      <body>
+        {@inner_content}
+      </body>
+    </html>
+    """
+
+    web_module_snake =
+      web_module
+      |> Module.split()
+      |> List.last()
+      |> Macro.underscore()
+
+    path = "lib/#{web_module_snake}/components/layouts/root.html.heex"
+
+    Igniter.create_new_file(igniter, path, layout_content, on_exists: :skip)
+  end
+
+  defp create_logo_svg(igniter) do
+    content = """
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 71 48" fill="currentColor" aria-hidden="true">
+      <path
+        d="m26.371 33.477-.552-.1c-3.92-.729-6.397-3.1-7.57-6.829-.733-2.324.597-4.035 3.035-4.148 1.995-.092 3.362 1.055 4.57 2.39 1.557 1.72 2.984 3.558 4.514 5.305 2.202 2.515 4.797 4.134 8.347 3.634 3.183-.448 5.958-1.725 8.371-3.828.363-.316.761-.592 1.144-.886l-.241-.284c-2.027.63-4.093.841-6.205.735-3.195-.16-6.24-.828-8.964-2.582-2.486-1.601-4.319-3.746-5.19-6.611-.704-2.315.736-3.934 3.135-3.6.948.133 1.746.56 2.463 1.165.583.493 1.143 1.015 1.738 1.493 2.8 2.25 6.712 2.375 10.265-.068-5.842-.026-9.817-3.24-13.308-7.313-1.366-1.594-2.7-3.216-4.095-4.785-2.698-3.036-5.692-5.71-9.79-6.623C12.8-.623 7.745.14 2.893 2.361 1.926 2.804.997 3.319 0 4.149c.494 0 .763.006 1.032 0 2.446-.064 4.28 1.023 5.602 3.024.962 1.457 1.415 3.104 1.761 4.798.513 2.515.247 5.078.544 7.605.761 6.494 4.08 11.026 10.26 13.346 2.267.852 4.591 1.135 7.172.555ZM10.751 3.852c-.976.246-1.756-.148-2.56-.962 1.377-.343 2.592-.476 3.897-.528-.107.848-.607 1.306-1.336 1.49Zm32.002 37.924c-.085-.626-.62-.901-1.04-1.228-1.857-1.446-4.03-1.958-6.333-2-1.375-.026-2.735-.128-4.031-.61-.595-.22-1.26-.505-1.244-1.272.015-.78.693-1 1.31-1.184.505-.15 1.026-.247 1.6-.382-1.46-.936-2.886-1.065-4.787-.3-2.993 1.202-5.943 1.06-8.926-.017-1.684-.608-3.179-1.563-4.735-2.408l-.077.057c1.29 2.115 3.034 3.817 5.004 5.271 3.793 2.8 7.936 4.471 12.784 3.73A66.714 66.714 0 0 1 37 40.877c1.98-.16 3.866.398 5.753.899Zm-9.14-30.345c-.105-.076-.206-.266-.42-.069 1.745 2.36 3.985 4.098 6.683 5.193 4.354 1.767 8.773 2.07 13.293.51 3.51-1.21 6.033-.028 7.343 3.38.19-3.955-2.137-6.837-5.843-7.401-2.084-.318-4.01.373-5.962.94-5.434 1.575-10.485.798-15.094-2.553Zm27.085 15.425c.708.059 1.416.123 2.124.185-1.6-1.405-3.55-1.517-5.523-1.404-3.003.17-5.167 1.903-7.14 3.972-1.739 1.824-3.31 3.87-5.903 4.604.043.078.054.117.066.117.35.005.699.021 1.047.005 3.768-.17 7.317-.965 10.14-3.7.89-.86 1.685-1.817 2.544-2.71.716-.746 1.584-1.159 2.645-1.07Zm-8.753-4.67c-2.812.246-5.254 1.409-7.548 2.943-1.766 1.18-3.654 1.738-5.776 1.37-.374-.066-.75-.114-1.124-.17l-.013.156c.135.07.265.151.405.207.354.14.702.308 1.07.395 4.083.971 7.992.474 11.516-1.803 2.221-1.435 4.521-1.707 7.013-1.336.252.038.503.083.756.107.234.022.479.255.795.003-2.179-1.574-4.526-2.096-7.094-1.872Zm-10.049-9.544c1.475.051 2.943-.142 4.486-1.059-.452.04-.643.04-.827.076-2.126.424-4.033-.04-5.733-1.383-.623-.493-1.257-.974-1.889-1.457-2.503-1.914-5.374-2.555-8.514-2.5.05.154.054.26.108.315 3.417 3.455 7.371 5.836 12.369 6.008Zm24.727 17.731c-2.114-2.097-4.952-2.367-7.578-.537 1.738.078 3.043.632 4.101 1.728a13 13 0 0 0 1.182 1.106c1.6 1.29 4.311 1.352 5.896.155-1.861-.726-1.861-.726-3.601-2.452Zm-21.058 16.06c-1.858-3.46-4.981-4.24-8.59-4.008a9.667 9.667 0 0 1 2.977 1.39c.84.586 1.547 1.311 2.243 2.055 1.38 1.473 3.534 2.376 4.962 2.07-.656-.412-1.238-.848-1.592-1.507Zl-.006.006-.036-.004.021.018.012.053Za.127.127 0 0 0 .015.043c.005.008.038 0 .058-.002Zl-.008.01.005.026.024.014Z"
+        fill="#FD4F00"
+      />
+    </svg>
+    """
+
+    Igniter.create_new_file(igniter, "priv/static/images/logo.svg", content, on_exists: :skip)
+  end
+
+  defp create_daisy_css(igniter) do
+    content = daisy_css_content()
+
+    Igniter.create_new_file(igniter, "assets/css/phx-daisy.css", content, on_exists: :skip)
+  end
+
+  defp daisy_css_content do
+    """
+    /* daisyUI Tailwind Plugin. You can update this file by fetching the latest version with:
+       curl -sLO https://github.com/saadeghi/daisyui/releases/latest/download/daisyui.js
+       Make sure to look at the daisyUI changelog: https://daisyui.com/docs/changelog/ */
+    @plugin "../vendor/daisyui" {
+      themes: false;
+    }
+
+    /* daisyUI theme plugin. You can update this file by fetching the latest version with:
+      curl -sLO https://github.com/saadeghi/daisyui/releases/latest/download/daisyui-theme.js
+      We ship with two themes, a light one inspired on Phoenix colours and a dark one inspired
+      on Elixir colours. Build your own at: https://daisyui.com/theme-generator/ */
+    @plugin "../vendor/daisyui-theme" {
+      name: "dark";
+      default: false;
+      prefersdark: true;
+      color-scheme: "dark";
+      --color-base-100: oklch(30.33% 0.016 252.42);
+      --color-base-200: oklch(25.26% 0.014 253.1);
+      --color-base-300: oklch(20.15% 0.012 254.09);
+      --color-base-content: oklch(97.807% 0.029 256.847);
+      --color-primary: oklch(58% 0.233 277.117);
+      --color-primary-content: oklch(96% 0.018 272.314);
+      --color-secondary: oklch(58% 0.233 277.117);
+      --color-secondary-content: oklch(96% 0.018 272.314);
+      --color-accent: oklch(60% 0.25 292.717);
+      --color-accent-content: oklch(96% 0.016 293.756);
+      --color-neutral: oklch(37% 0.044 257.287);
+      --color-neutral-content: oklch(98% 0.003 247.858);
+      --color-info: oklch(58% 0.158 241.966);
+      --color-info-content: oklch(97% 0.013 236.62);
+      --color-success: oklch(60% 0.118 184.704);
+      --color-success-content: oklch(98% 0.014 180.72);
+      --color-warning: oklch(66% 0.179 58.318);
+      --color-warning-content: oklch(98% 0.022 95.277);
+      --color-error: oklch(58% 0.253 17.585);
+      --color-error-content: oklch(96% 0.015 12.422);
+      --radius-selector: 0.25rem;
+      --radius-field: 0.25rem;
+      --radius-box: 0.5rem;
+      --size-selector: 0.21875rem;
+      --size-field: 0.21875rem;
+      --border: 1.5px;
+      --depth: 1;
+      --noise: 0;
+    }
+
+    @plugin "../vendor/daisyui-theme" {
+      name: "light";
+      default: true;
+      prefersdark: false;
+      color-scheme: "light";
+      --color-base-100: oklch(98% 0 0);
+      --color-base-200: oklch(96% 0.001 286.375);
+      --color-base-300: oklch(92% 0.004 286.32);
+      --color-base-content: oklch(21% 0.006 285.885);
+      --color-primary: oklch(70% 0.213 47.604);
+      --color-primary-content: oklch(98% 0.016 73.684);
+      --color-secondary: oklch(55% 0.027 264.364);
+      --color-secondary-content: oklch(98% 0.002 247.839);
+      --color-accent: oklch(0% 0 0);
+      --color-accent-content: oklch(100% 0 0);
+      --color-neutral: oklch(44% 0.017 285.786);
+      --color-neutral-content: oklch(98% 0 0);
+      --color-info: oklch(62% 0.214 259.815);
+      --color-info-content: oklch(97% 0.014 254.604);
+      --color-success: oklch(70% 0.14 182.503);
+      --color-success-content: oklch(98% 0.014 180.72);
+      --color-warning: oklch(66% 0.179 58.318);
+      --color-warning-content: oklch(98% 0.022 95.277);
+      --color-error: oklch(58% 0.253 17.585);
+      --color-error-content: oklch(96% 0.015 12.422);
+      --radius-selector: 0.25rem;
+      --radius-field: 0.25rem;
+      --radius-box: 0.5rem;
+      --size-selector: 0.21875rem;
+      --size-field: 0.21875rem;
+      --border: 1.5px;
+      --depth: 1;
+      --noise: 0;
+    }
+
+    /* Use the data attribute for dark mode */
+    @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
+    """
+  end
+
+  defp download_vendor_file(igniter, filename) do
+    path = "assets/vendor/#{filename}"
+
+    case Rewrite.source(igniter.rewrite, path) do
+      {:ok, _} ->
+        igniter
+
+      {:error, _} ->
+        if File.exists?(path) do
+          igniter
+        else
+          url = "#{@daisyui_base_url}/#{filename}"
+
+          case fetch_url(url) do
+            {:ok, body} ->
+              Igniter.create_new_file(igniter, path, body, on_exists: :skip)
+
+            {:error, reason} ->
+              Igniter.add_notice(
+                igniter,
+                """
+                Could not download #{filename} from #{url}: #{reason}
+
+                Please download it manually:
+                  curl -sLo #{path} #{url}
+                """
+              )
+          end
+        end
+    end
+  end
+
+  defp fetch_url(url) do
+    Application.ensure_all_started(:inets)
+    Application.ensure_all_started(:ssl)
+    Application.ensure_all_started(:public_key)
+
+    url_charlist = String.to_charlist(url)
+
+    http_opts = [
+      ssl: [
+        verify: :verify_peer,
+        cacerts: :public_key.cacerts_get(),
+        customize_hostname_check: [
+          match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+        ]
+      ],
+      autoredirect: true
+    ]
+
+    case :httpc.request(:get, {url_charlist, []}, http_opts, body_format: :binary) do
+      {:ok, {{_, 200, _}, _headers, body}} -> {:ok, body}
+      {:ok, {{_, status, _}, _, _}} -> {:error, "HTTP #{status}"}
+      {:error, reason} -> {:error, inspect(reason)}
+    end
+  end
+end

--- a/lib/mix/tasks/phx/install/html/daisy.ex
+++ b/lib/mix/tasks/phx/install/html/daisy.ex
@@ -699,32 +699,34 @@ defmodule Mix.Tasks.Phx.Install.Html.Daisy do
   defp download_vendor_file(igniter, filename) do
     path = "assets/vendor/#{filename}"
 
-    case Rewrite.source(igniter.rewrite, path) do
-      {:ok, _} ->
-        igniter
+    if vendor_file_exists?(igniter, path) do
+      igniter
+    else
+      fetch_and_create_vendor_file(igniter, path, filename)
+    end
+  end
 
-      {:error, _} ->
-        if File.exists?(path) do
-          igniter
-        else
-          url = "#{@daisyui_base_url}/#{filename}"
+  defp vendor_file_exists?(igniter, path) do
+    match?({:ok, _}, Rewrite.source(igniter.rewrite, path)) or File.exists?(path)
+  end
 
-          case fetch_url(url) do
-            {:ok, body} ->
-              Igniter.create_new_file(igniter, path, body, on_exists: :skip)
+  defp fetch_and_create_vendor_file(igniter, path, filename) do
+    url = "#{@daisyui_base_url}/#{filename}"
 
-            {:error, reason} ->
-              Igniter.add_notice(
-                igniter,
-                """
-                Could not download #{filename} from #{url}: #{reason}
+    case fetch_url(url) do
+      {:ok, body} ->
+        Igniter.create_new_file(igniter, path, body, on_exists: :skip)
 
-                Please download it manually:
-                  curl -sLo #{path} #{url}
-                """
-              )
-          end
-        end
+      {:error, reason} ->
+        Igniter.add_notice(
+          igniter,
+          """
+          Could not download #{filename} from #{url}: #{reason}
+
+          Please download it manually:
+            curl -sLo #{path} #{url}
+          """
+        )
     end
   end
 

--- a/lib/mix/tasks/phx/install/html/tailwind.ex
+++ b/lib/mix/tasks/phx/install/html/tailwind.ex
@@ -1,0 +1,393 @@
+defmodule Mix.Tasks.Phx.Install.Html.Tailwind do
+  @shortdoc "Adds Tailwind-only HTML components"
+  @moduledoc """
+  Adds plain Tailwind CSS core components, layouts, and templates.
+
+  This task creates:
+  - CoreComponents module with flash, flash_group, simple_form, button, input
+  - Layouts module with `embed_templates`
+  - Root HTML layout (`root.html.heex`)
+  - App layout (`app.html.heex`)
+
+  ## Usage
+
+      mix phx.install.html.tailwind
+
+  This task is typically composed by `mix phx.install.html` rather than called directly.
+  """
+  use Igniter.Mix.Task
+
+  @impl Igniter.Mix.Task
+  def info(_argv, _composing_task) do
+    %Igniter.Mix.Task.Info{
+      group: :phoenix,
+      example: "mix phx.install.html.tailwind"
+    }
+  end
+
+  @impl Igniter.Mix.Task
+  def igniter(igniter) do
+    web_module = Igniter.Libs.Phoenix.web_module(igniter)
+
+    igniter
+    |> create_core_components(web_module)
+    |> create_layouts_module(web_module)
+    |> create_root_layout(web_module)
+    |> create_app_layout(web_module)
+  end
+
+  defp create_core_components(igniter, web_module) do
+    core_components_module = Module.concat(web_module, CoreComponents)
+
+    Igniter.Project.Module.find_and_update_or_create_module(
+      igniter,
+      core_components_module,
+      """
+      @moduledoc \"\"\"
+      Provides core UI components.
+
+      The components in this module use Tailwind CSS utility classes directly.
+      \"\"\"
+
+      use Phoenix.Component
+
+      @doc \"\"\"
+      Renders flash notices.
+
+      ## Examples
+
+          <.flash kind={:info} flash={@flash} />
+      \"\"\"
+      attr :id, :string, doc: "the optional id of flash container"
+      attr :flash, :map, default: %{}, doc: "the map of flash messages to display"
+      attr :title, :string, default: nil
+      attr :kind, :atom, values: [:info, :error], doc: "used for styling and flash lookup"
+      attr :rest, :global, doc: "the arbitrary HTML attributes to add to the flash container"
+
+      slot :inner_block, doc: "the optional inner block that renders the flash message"
+
+      def flash(assigns) do
+        assigns = assign_new(assigns, :id, fn -> "flash-\#{assigns.kind}" end)
+
+        ~H\"\"\"
+        <div
+          :if={msg = render_slot(@inner_block) || Phoenix.Flash.get(@flash, @kind)}
+          id={@id}
+          role="alert"
+          class={"flash flash-\#{@kind}"}
+          {@rest}
+        >
+          <p :if={@title} class="flash-title">{@title}</p>
+          <p class="flash-message">{msg}</p>
+        </div>
+        \"\"\"
+      end
+
+      @doc \"\"\"
+      Shows the flash group with standard titles and content.
+
+      ## Examples
+
+          <.flash_group flash={@flash} />
+      \"\"\"
+      attr :flash, :map, required: true, doc: "the map of flash messages"
+      attr :id, :string, default: "flash-group", doc: "the optional id of flash container"
+
+      def flash_group(assigns) do
+        ~H\"\"\"
+        <div id={@id}>
+          <.flash kind={:info} flash={@flash} />
+          <.flash kind={:error} flash={@flash} />
+        </div>
+        \"\"\"
+      end
+
+      @doc \"\"\"
+      Renders a simple form.
+
+      ## Examples
+
+          <.simple_form for={@form} phx-change="validate" phx-submit="save">
+            <.input field={@form[:email]} label="Email"/>
+            <:actions>
+              <.button>Save</.button>
+            </:actions>
+          </.simple_form>
+      \"\"\"
+      attr :for, :any, required: true, doc: "the data structure for the form"
+      attr :as, :any, default: nil, doc: "the server side parameter to collect all input under"
+
+      attr :rest, :global,
+        include: ~w(autocomplete name rel action enctype method novalidate target multipart),
+        doc: "the arbitrary HTML attributes to apply to the form tag"
+
+      slot :inner_block, required: true
+      slot :actions, doc: "the slot for form actions, such as a submit button"
+
+      def simple_form(assigns) do
+        ~H\"\"\"
+        <.form :let={f} for={@for} as={@as} {@rest}>
+          {render_slot(@inner_block, f)}
+          <div :for={action <- @actions}>
+            {render_slot(action, f)}
+          </div>
+        </.form>
+        \"\"\"
+      end
+
+      @doc \"\"\"
+      Renders a button with navigation support.
+
+      ## Examples
+
+          <.button>Send!</.button>
+          <.button phx-click="go" variant="primary">Send!</.button>
+          <.button navigate={~p"/"}>Home</.button>
+      \"\"\"
+      attr :rest, :global, include: ~w(href navigate patch method download name value disabled form)
+      attr :class, :any
+      attr :variant, :string, values: ~w(primary)
+      slot :inner_block, required: true
+
+      def button(%{rest: rest} = assigns) do
+        variants = %{"primary" => "button-primary", nil => "button"}
+
+        assigns =
+          assign_new(assigns, :class, fn ->
+            [Map.fetch!(variants, assigns[:variant])]
+          end)
+
+        if rest[:href] || rest[:navigate] || rest[:patch] do
+          ~H\"\"\"
+          <.link class={@class} {@rest}>
+            {render_slot(@inner_block)}
+          </.link>
+          \"\"\"
+        else
+          ~H\"\"\"
+          <button class={@class} {@rest}>
+            {render_slot(@inner_block)}
+          </button>
+          \"\"\"
+        end
+      end
+
+      @doc \"\"\"
+      Renders an input with label and error messages.
+
+      A `Phoenix.HTML.FormField` may be passed as argument,
+      which is used to retrieve the input name, id, and values.
+      Otherwise all attributes may be passed explicitly.
+
+      ## Examples
+
+          <.input field={@form[:email]} type="email" />
+          <.input name="my-input" errors={["oh no!"]} />
+      \"\"\"
+      attr :id, :any, default: nil
+      attr :name, :any
+      attr :label, :string, default: nil
+      attr :value, :any
+
+      attr :type, :string,
+        default: "text",
+        values: ~w(checkbox color date datetime-local email file hidden month number password
+                   range search select tel text textarea time url week)
+
+      attr :field, Phoenix.HTML.FormField,
+        doc: "a form field struct retrieved from the form, for example: @form[:email]"
+
+      attr :errors, :list, default: []
+      attr :checked, :boolean, doc: "the checked flag for checkbox inputs"
+      attr :prompt, :string, default: nil, doc: "the prompt for select inputs"
+      attr :options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2"
+      attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
+
+      attr :rest, :global,
+        include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
+                    multiple pattern placeholder readonly required rows size step)
+
+      def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
+        errors = if Phoenix.Component.used_input?(field), do: field.errors, else: []
+
+        assigns
+        |> assign(field: nil, id: assigns.id || field.id)
+        |> assign(:errors, Enum.map(errors, &translate_error(&1)))
+        |> assign_new(:name, fn -> if assigns.multiple, do: field.name <> "[]", else: field.name end)
+        |> assign_new(:value, fn -> field.value end)
+        |> input()
+      end
+
+      def input(%{type: "checkbox"} = assigns) do
+        assigns =
+          assign_new(assigns, :checked, fn ->
+            Phoenix.HTML.Form.normalize_value("checkbox", assigns[:value])
+          end)
+
+        ~H\"\"\"
+        <div>
+          <label>
+            <input type="hidden" name={@name} value="false" disabled={@rest[:disabled]} />
+            <input
+              type="checkbox"
+              id={@id}
+              name={@name}
+              value="true"
+              checked={@checked}
+              {@rest}
+            />
+            {@label}
+          </label>
+          <.error :for={msg <- @errors}>{msg}</.error>
+        </div>
+        \"\"\"
+      end
+
+      def input(%{type: "select"} = assigns) do
+        ~H\"\"\"
+        <div>
+          <label :if={@label}>{@label}</label>
+          <select id={@id} name={@name} multiple={@multiple} {@rest}>
+            <option :if={@prompt} value="">{@prompt}</option>
+            {Phoenix.HTML.Form.options_for_select(@options, @value)}
+          </select>
+          <.error :for={msg <- @errors}>{msg}</.error>
+        </div>
+        \"\"\"
+      end
+
+      def input(%{type: "textarea"} = assigns) do
+        ~H\"\"\"
+        <div>
+          <label :if={@label}>{@label}</label>
+          <textarea id={@id} name={@name} {@rest}>{Phoenix.HTML.Form.normalize_value("textarea", @value)}</textarea>
+          <.error :for={msg <- @errors}>{msg}</.error>
+        </div>
+        \"\"\"
+      end
+
+      def input(%{type: "hidden"} = assigns) do
+        ~H\"\"\"
+        <input type="hidden" id={@id} name={@name} value={@value} {@rest} />
+        \"\"\"
+      end
+
+      def input(assigns) do
+        ~H\"\"\"
+        <div>
+          <label :if={@label}>{@label}</label>
+          <input
+            type={@type}
+            name={@name}
+            id={@id}
+            value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+            {@rest}
+          />
+          <.error :for={msg <- @errors}>{msg}</.error>
+        </div>
+        \"\"\"
+      end
+
+      defp error(assigns) do
+        ~H\"\"\"
+        <p class="error">{render_slot(@inner_block)}</p>
+        \"\"\"
+      end
+
+      @doc \"\"\"
+      Translates an error message.
+      \"\"\"
+      def translate_error({msg, opts}) do
+        Enum.reduce(opts, msg, fn {key, value}, acc ->
+          String.replace(acc, "%{\#{key}}", fn _ -> to_string(value) end)
+        end)
+      end
+
+      @doc \"\"\"
+      Translates the errors for a field from a keyword list of errors.
+      \"\"\"
+      def translate_errors(errors, field) when is_list(errors) do
+        for {^field, {msg, opts}} <- errors, do: translate_error({msg, opts})
+      end
+      """,
+      fn zipper -> {:ok, zipper} end
+    )
+  end
+
+  defp create_layouts_module(igniter, web_module) do
+    layouts_module = Module.concat(web_module, Layouts)
+
+    Igniter.Project.Module.find_and_update_or_create_module(
+      igniter,
+      layouts_module,
+      """
+      @moduledoc \"\"\"
+      This module holds different layouts used by your application.
+
+      See the `layouts` directory for all templates available.
+      \"\"\"
+      use #{inspect(web_module)}, :html
+
+      embed_templates "layouts/*"
+      """,
+      fn zipper -> {:ok, zipper} end
+    )
+  end
+
+  defp create_root_layout(igniter, web_module) do
+    app_module =
+      web_module
+      |> Module.split()
+      |> List.first()
+      |> then(fn name -> String.replace(name, "Web", "") end)
+
+    layout_content = """
+    <!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="csrf-token" content={get_csrf_token()} />
+        <.live_title default="#{app_module}">
+          {assigns[:page_title]}
+        </.live_title>
+        <link phx-track-static rel="stylesheet" href={~p"/assets/css/app.css"} />
+        <script defer phx-track-static type="text/javascript" src={~p"/assets/js/app.js"}>
+        </script>
+      </head>
+      <body>
+        {@inner_content}
+      </body>
+    </html>
+    """
+
+    web_module_snake =
+      web_module
+      |> Module.split()
+      |> List.last()
+      |> Macro.underscore()
+
+    path = "lib/#{web_module_snake}/components/layouts/root.html.heex"
+
+    Igniter.create_new_file(igniter, path, layout_content, on_exists: :skip)
+  end
+
+  defp create_app_layout(igniter, web_module) do
+    layout_content = """
+    <main class="container">
+      <.flash_group flash={@flash} />
+      {@inner_content}
+    </main>
+    """
+
+    web_module_snake =
+      web_module
+      |> Module.split()
+      |> List.last()
+      |> Macro.underscore()
+
+    path = "lib/#{web_module_snake}/components/layouts/app.html.heex"
+
+    Igniter.create_new_file(igniter, path, layout_content, on_exists: :skip)
+  end
+end

--- a/lib/mix/tasks/phx/install/live.ex
+++ b/lib/mix/tasks/phx/install/live.ex
@@ -30,8 +30,10 @@ defmodule Mix.Tasks.Phx.Install.Live do
       example: "mix phx.install.live",
       adds_deps: [{:phoenix_live_view, "~> 1.0"}],
       schema: [
-        live_signing_salt: :string
+        live_signing_salt: :string,
+        ui: :string
       ],
+      defaults: [ui: "daisy"],
       composes: ["phx.install.html"]
     }
   end
@@ -44,10 +46,11 @@ defmodule Mix.Tasks.Phx.Install.Live do
 
     opts = igniter.args.options
     live_signing_salt = opts[:live_signing_salt] || PhxInstall.random_string(8)
+    ui = opts[:ui] || "daisy"
 
     igniter
     |> Igniter.Project.Deps.add_dep({:phoenix_live_view, "~> 1.0"})
-    |> Igniter.compose_task("phx.install.html")
+    |> Igniter.compose_task("phx.install.html", ["--ui", ui])
     |> add_live_view_config(app_name, endpoint_module, live_signing_salt)
     |> add_socket_to_endpoint(endpoint_module)
     |> add_live_macros_to_web_module(web_module)

--- a/lib/mix/tasks/phx/install/page.ex
+++ b/lib/mix/tasks/phx/install/page.ex
@@ -21,19 +21,23 @@ defmodule Mix.Tasks.Phx.Install.Page do
   def info(_argv, _composing_task) do
     %Igniter.Mix.Task.Info{
       group: :phoenix,
-      example: "mix phx.install.page"
+      example: "mix phx.install.page",
+      schema: [ui: :string],
+      defaults: [ui: "daisy"]
     }
   end
 
   @impl Igniter.Mix.Task
   def igniter(igniter) do
     web_module = Igniter.Libs.Phoenix.web_module(igniter)
+    opts = igniter.args.options
+    ui = opts[:ui] || "daisy"
 
     igniter
     |> Igniter.Project.Deps.add_dep({:phoenix, "~> 1.7"})
     |> create_page_controller(web_module)
     |> create_page_html(web_module)
-    |> create_home_template(web_module)
+    |> create_home_template(web_module, ui)
     |> add_browser_scope_to_router(web_module)
   end
 
@@ -69,7 +73,7 @@ defmodule Mix.Tasks.Phx.Install.Page do
     )
   end
 
-  defp create_home_template(igniter, web_module) do
+  defp create_home_template(igniter, web_module, ui) do
     web_module_snake =
       web_module
       |> Module.split()
@@ -78,7 +82,13 @@ defmodule Mix.Tasks.Phx.Install.Page do
 
     path = "lib/#{web_module_snake}/controllers/page_html/home.html.heex"
 
-    Igniter.create_new_file(igniter, path, home_template(), on_exists: :skip)
+    template =
+      case ui do
+        "daisy" -> home_template_daisy()
+        _ -> home_template_tailwind()
+      end
+
+    Igniter.create_new_file(igniter, path, template, on_exists: :skip)
   end
 
   defp add_browser_scope_to_router(igniter, web_module) do
@@ -163,7 +173,7 @@ defmodule Mix.Tasks.Phx.Install.Page do
     end
   end
 
-  defp home_template do
+  defp home_template_tailwind do
     """
     <.flash_group flash={@flash} />
     <div class="left-[40rem] fixed inset-y-0 right-0 z-0 hidden lg:block xl:left-[50rem]">
@@ -355,6 +365,213 @@ defmodule Mix.Tasks.Phx.Install.Page do
                     viewBox="0 0 20 20"
                     aria-hidden="true"
                     class="h-4 w-4 fill-zinc-400 group-hover:fill-zinc-900"
+                  >
+                    <path d="M1 12.5A4.5 4.5 0 005.5 17H15a4 4 0 001.866-7.539 3.504 3.504 0 00-4.504-4.272A4.5 4.5 0 004.06 8.235 4.502 4.502 0 001 12.5z" />
+                  </svg>
+                  Deploy your application
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp home_template_daisy do
+    ~S"""
+    <Layouts.flash_group flash={@flash} />
+    <div class="left-[40rem] fixed inset-y-0 right-0 z-0 hidden lg:block xl:left-[50rem]">
+      <svg
+        viewBox="0 0 1480 957"
+        fill="none"
+        aria-hidden="true"
+        class="absolute inset-0 h-full w-full"
+        preserveAspectRatio="xMinYMid slice"
+      >
+        <path fill="#EE7868" d="M0 0h1480v957H0z" />
+        <path
+          d="M137.542 466.27c-582.851-48.41-988.806-82.127-1608.412 658.2l67.39 810 3083.15-256.51L1535.94-49.622l-98.36 8.183C1269.29 281.468 734.115 515.799 146.47 467.012l-8.928-.742Z"
+          fill="#FF9F92"
+        />
+        <path
+          d="M371.028 528.664C-169.369 304.988-545.754 149.198-1361.45 665.565l-182.58 792.025 3014.73 694.98 389.42-1689.25-96.18-22.171C1505.28 697.438 924.153 757.586 379.305 532.09l-8.277-3.426Z"
+          fill="#FA8372"
+        />
+        <path
+          d="M359.326 571.714C-104.765 215.795-428.003-32.102-1349.55 255.554l-282.3 1224.596 3047.04 722.01 312.24-1354.467C1411.25 1028.3 834.355 935.995 366.435 577.166l-7.109-5.452Z"
+          fill="#E96856"
+          fill-opacity=".6"
+        />
+        <path
+          d="M1593.87 1236.88c-352.15 92.63-885.498-145.85-1244.602-613.557l-5.455-7.105C-12.347 152.31-260.41-170.8-1225-131.458l-368.63 1599.048 3057.19 704.76 130.31-935.47Z"
+          fill="#C42652"
+          fill-opacity=".2"
+        />
+        <path
+          d="M1411.91 1526.93c-363.79 15.71-834.312-330.6-1085.883-863.909l-3.822-8.102C72.704 125.95-101.074-242.476-1052.01-408.907l-699.85 1484.267 2837.75 1338.01 326.02-886.44Z"
+          fill="#A41C42"
+          fill-opacity=".2"
+        />
+        <path
+          d="M1116.26 1863.69c-355.457-78.98-720.318-535.27-825.287-1115.521l-1.594-8.816C185.286 163.833 112.786-237.016-762.678-643.898L-1822.83 608.665 571.922 2635.55l544.338-771.86Z"
+          fill="#A41C42"
+          fill-opacity=".2"
+        />
+      </svg>
+    </div>
+    <div class="px-4 py-10 sm:px-6 sm:py-28 lg:px-8 xl:px-28 xl:py-32">
+      <div class="mx-auto max-w-xl lg:mx-0">
+        <svg viewBox="0 0 71 48" class="h-12" aria-hidden="true">
+          <path
+            d="m26.371 33.477-.552-.1c-3.92-.729-6.397-3.1-7.57-6.829-.733-2.324.597-4.035 3.035-4.148 1.995-.092 3.362 1.055 4.57 2.39 1.557 1.72 2.984 3.558 4.514 5.305 2.202 2.515 4.797 4.134 8.347 3.634 3.183-.448 5.958-1.725 8.371-3.828.363-.316.761-.592 1.144-.886l-.241-.284c-2.027.63-4.093.841-6.205.735-3.195-.16-6.24-.828-8.964-2.582-2.486-1.601-4.319-3.746-5.19-6.611-.704-2.315.736-3.934 3.135-3.6.948.133 1.746.56 2.463 1.165.583.493 1.143 1.015 1.738 1.493 2.8 2.25 6.712 2.375 10.265-.068-5.842-.026-9.817-3.24-13.308-7.313-1.366-1.594-2.7-3.216-4.095-4.785-2.698-3.036-5.692-5.71-9.79-6.623C12.8-.623 7.745.14 2.893 2.361 1.926 2.804.997 3.319 0 4.149c.494 0 .763.006 1.032 0 2.446-.064 4.28 1.023 5.602 3.024.962 1.457 1.415 3.104 1.761 4.798.513 2.515.247 5.078.544 7.605.761 6.494 4.08 11.026 10.26 13.346 2.267.852 4.591 1.135 7.172.555ZM10.751 3.852c-.976.246-1.756-.148-2.56-.962 1.377-.343 2.592-.476 3.897-.528-.107.848-.607 1.306-1.336 1.49Zm32.002 37.924c-.085-.626-.62-.901-1.04-1.228-1.857-1.446-4.03-1.958-6.333-2-1.375-.026-2.735-.128-4.031-.61-.595-.22-1.26-.505-1.244-1.272.015-.78.693-1 1.31-1.184.505-.15 1.026-.247 1.6-.382-1.46-.936-2.886-1.065-4.787-.3-2.993 1.202-5.943 1.06-8.926-.017-1.684-.608-3.179-1.563-4.735-2.408l-.077.057c1.29 2.115 3.034 3.817 5.004 5.271 3.793 2.8 7.936 4.471 12.784 3.73A66.714 66.714 0 0 1 37 40.877c1.98-.16 3.866.398 5.753.899Zm-9.14-30.345c-.105-.076-.206-.266-.42-.069 1.745 2.36 3.985 4.098 6.683 5.193 4.354 1.767 8.773 2.07 13.293.51 3.51-1.21 6.033-.028 7.343 3.38.19-3.955-2.137-6.837-5.843-7.401-2.084-.318-4.01.373-5.962.94-5.434 1.575-10.485.798-15.094-2.553Zm27.085 15.425c.708.059 1.416.123 2.124.185-1.6-1.405-3.55-1.517-5.523-1.404-3.003.17-5.167 1.903-7.14 3.972-1.739 1.824-3.31 3.87-5.903 4.604.043.078.054.117.066.117.35.005.699.021 1.047.005 3.768-.17 7.317-.965 10.14-3.7.89-.86 1.685-1.817 2.544-2.71.716-.746 1.584-1.159 2.645-1.07Zm-8.753-4.67c-2.812.246-5.254 1.409-7.548 2.943-1.766 1.18-3.654 1.738-5.776 1.37-.374-.066-.75-.114-1.124-.17l-.013.156c.135.07.265.151.405.207.354.14.702.308 1.07.395 4.083.971 7.992.474 11.516-1.803 2.221-1.435 4.521-1.707 7.013-1.336.252.038.503.083.756.107.234.022.479.255.795.003-2.179-1.574-4.526-2.096-7.094-1.872Zm-10.049-9.544c1.475.051 2.943-.142 4.486-1.059-.452.04-.643.04-.827.076-2.126.424-4.033-.04-5.733-1.383-.623-.493-1.257-.974-1.889-1.457-2.503-1.914-5.374-2.555-8.514-2.5.05.154.054.26.108.315 3.417 3.455 7.371 5.836 12.369 6.008Zm24.727 17.731c-2.114-2.097-4.952-2.367-7.578-.537 1.738.078 3.043.632 4.101 1.728a13 13 0 0 0 1.182 1.106c1.6 1.29 4.311 1.352 5.896.155-1.861-.726-1.861-.726-3.601-2.452Zm-21.058 16.06c-1.858-3.46-4.981-4.24-8.59-4.008a9.667 9.667 0 0 1 2.977 1.39c.84.586 1.547 1.311 2.243 2.055 1.38 1.473 3.534 2.376 4.962 2.07-.656-.412-1.238-.848-1.592-1.507Zl-.006.006-.036-.004.021.018.012.053Za.127.127 0 0 0 .015.043c.005.008.038 0 .058-.002Zl-.008.01.005.026.024.014Z"
+            fill="#FD4F00"
+          />
+        </svg>
+        <div class="mt-10 flex justify-between items-center">
+          <h1 class="flex items-center text-sm font-semibold leading-6">
+            Phoenix Framework
+            <small class="badge badge-warning badge-sm ml-3">
+              v{Application.spec(:phoenix, :vsn)}
+            </small>
+          </h1>
+          <Layouts.theme_toggle />
+        </div>
+
+        <p class="text-[2rem] mt-4 font-semibold leading-10 tracking-tighter text-balance">
+          Peace of mind from prototype to production.
+        </p>
+        <p class="mt-4 leading-7 text-base-content/70">
+          Build rich, interactive web applications quickly, with less code and fewer moving parts. Join our growing community of developers using Phoenix to craft APIs, HTML5 apps and more, for fun or at scale.
+        </p>
+        <div class="flex">
+          <div class="w-full sm:w-auto">
+            <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-3">
+              <a
+                href="https://hexdocs.pm/phoenix/overview.html"
+                class="group relative rounded-box px-6 py-4 text-sm font-semibold leading-6 sm:py-6"
+              >
+                <span class="absolute inset-0 rounded-box bg-base-200 transition group-hover:bg-base-300 sm:group-hover:scale-105">
+                </span>
+                <span class="relative flex items-center gap-4 sm:flex-col">
+                  <svg viewBox="0 0 24 24" fill="none" aria-hidden="true" class="h-6 w-6">
+                    <path d="m12 4 10-2v18l-10 2V4Z" fill="currentColor" fill-opacity=".15" />
+                    <path
+                      d="M12 4 2 2v18l10 2m0-18v18m0-18 10-2v18l-10 2"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                  Guides &amp; Docs
+                </span>
+              </a>
+              <a
+                href="https://github.com/phoenixframework/phoenix"
+                class="group relative rounded-box px-6 py-4 text-sm font-semibold leading-6 sm:py-6"
+              >
+                <span class="absolute inset-0 rounded-box bg-base-200 transition group-hover:bg-base-300 sm:group-hover:scale-105">
+                </span>
+                <span class="relative flex items-center gap-4 sm:flex-col">
+                  <svg viewBox="0 0 24 24" aria-hidden="true" class="h-6 w-6">
+                    <path
+                      fill="currentColor"
+                      fill-rule="evenodd"
+                      clip-rule="evenodd"
+                      d="M12 0C5.37 0 0 5.506 0 12.303c0 5.445 3.435 10.043 8.205 11.674.6.107.825-.262.825-.585 0-.292-.015-1.261-.015-2.291C6 21.67 5.22 20.346 4.98 19.654c-.135-.354-.72-1.446-1.23-1.738-.42-.23-1.02-.8-.015-.815.945-.015 1.62.892 1.845 1.261 1.08 1.86 2.805 1.338 3.495 1.015.105-.8.42-1.338.765-1.645-2.67-.308-5.46-1.37-5.46-6.075 0-1.338.465-2.446 1.23-3.307-.12-.308-.54-1.569.12-3.26 0 0 1.005-.323 3.3 1.26.96-.276 1.98-.415 3-.415s2.04.139 3 .416c2.295-1.6 3.3-1.261 3.3-1.261.66 1.691.24 2.952.12 3.26.765.861 1.23 1.953 1.23 3.307 0 4.721-2.805 5.767-5.475 6.075.435.384.81 1.122.81 2.276 0 1.645-.015 2.968-.015 3.383 0 .323.225.707.825.585a12.047 12.047 0 0 0 5.919-4.489A12.536 12.536 0 0 0 24 12.304C24 5.505 18.63 0 12 0Z"
+                    />
+                  </svg>
+                  Source Code
+                </span>
+              </a>
+              <a
+                href={"https://github.com/phoenixframework/phoenix/blob/v#{Application.spec(:phoenix, :vsn)}/CHANGELOG.md"}
+                class="group relative rounded-box px-6 py-4 text-sm font-semibold leading-6 sm:py-6"
+              >
+                <span class="absolute inset-0 rounded-box bg-base-200 transition group-hover:bg-base-300 sm:group-hover:scale-105">
+                </span>
+                <span class="relative flex items-center gap-4 sm:flex-col">
+                  <svg viewBox="0 0 24 24" fill="none" aria-hidden="true" class="h-6 w-6">
+                    <path
+                      d="M12 1v6M12 17v6"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <circle
+                      cx="12"
+                      cy="12"
+                      r="4"
+                      fill="currentColor"
+                      fill-opacity=".15"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                  Changelog
+                </span>
+              </a>
+            </div>
+            <div class="mt-10 grid grid-cols-1 gap-y-4 text-sm leading-6 text-base-content/80 sm:grid-cols-2">
+              <div>
+                <a
+                  href="https://elixirforum.com"
+                  class="group -mx-2 -my-0.5 inline-flex items-center gap-3 rounded-lg px-2 py-0.5 hover:bg-base-200 hover:text-base-content"
+                >
+                  <svg
+                    viewBox="0 0 16 16"
+                    aria-hidden="true"
+                    class="h-4 w-4 fill-base-content/40 group-hover:fill-base-content"
+                  >
+                    <path d="M8 13.833c3.866 0 7-2.873 7-6.416C15 3.873 11.866 1 8 1S1 3.873 1 7.417c0 1.081.292 2.1.808 2.995.606 1.05.806 2.399.086 3.375l-.208.283c-.285.386-.01.905.465.85.852-.098 2.048-.318 3.137-.81a3.717 3.717 0 0 1 1.91-.318c.263.027.53.041.802.041Z" />
+                  </svg>
+                  Discuss on the Elixir Forum
+                </a>
+              </div>
+              <div>
+                <a
+                  href="https://discord.gg/elixir"
+                  class="group -mx-2 -my-0.5 inline-flex items-center gap-3 rounded-lg px-2 py-0.5 hover:bg-base-200 hover:text-base-content"
+                >
+                  <svg
+                    viewBox="0 0 16 16"
+                    aria-hidden="true"
+                    class="h-4 w-4 fill-base-content/40 group-hover:fill-base-content"
+                  >
+                    <path d="M13.545 2.995c-1.02-.46-2.114-.8-3.257-.994a.05.05 0 0 0-.052.024c-.141.246-.297.567-.406.82a12.377 12.377 0 0 0-3.658 0 8.238 8.238 0 0 0-.412-.82.052.052 0 0 0-.052-.024 13.315 13.315 0 0 0-3.257.994.046.046 0 0 0-.021.018C.356 6.063-.213 9.036.066 11.973c.001.015.01.029.02.038a13.353 13.353 0 0 0 3.996 1.987.052.052 0 0 0 .056-.018c.308-.414.582-.85.818-1.309a.05.05 0 0 0-.028-.069 8.808 8.808 0 0 1-1.248-.585.05.05 0 0 1-.005-.084c.084-.062.168-.126.248-.191a.05.05 0 0 1 .051-.007c2.619 1.176 5.454 1.176 8.041 0a.05.05 0 0 1 .053.006c.08.065.164.13.248.192a.05.05 0 0 1-.004.084c-.399.23-.813.423-1.249.585a.05.05 0 0 0-.027.07c.24.457.514.893.817 1.307a.051.051 0 0 0 .056.019 13.31 13.31 0 0 0 4.001-1.987.05.05 0 0 0 .021-.037c.334-3.396-.559-6.345-2.365-8.96a.04.04 0 0 0-.021-.02Zm-8.198 7.19c-.789 0-1.438-.712-1.438-1.587 0-.874.637-1.586 1.438-1.586.807 0 1.45.718 1.438 1.586 0 .875-.637 1.587-1.438 1.587Zm5.316 0c-.788 0-1.438-.712-1.438-1.587 0-.874.637-1.586 1.438-1.586.807 0 1.45.718 1.438 1.586 0 .875-.63 1.587-1.438 1.587Z" />
+                  </svg>
+                  Join our Discord server
+                </a>
+              </div>
+              <div>
+                <a
+                  href="https://elixir-slack.community/"
+                  class="group -mx-2 -my-0.5 inline-flex items-center gap-3 rounded-lg px-2 py-0.5 hover:bg-base-200 hover:text-base-content"
+                >
+                  <svg
+                    viewBox="0 0 16 16"
+                    aria-hidden="true"
+                    class="h-4 w-4 fill-base-content/40 group-hover:fill-base-content"
+                  >
+                    <path d="M3.361 10.11a1.68 1.68 0 1 1-1.68-1.681h1.68v1.682ZM4.209 10.11a1.68 1.68 0 1 1 3.361 0v4.21a1.68 1.68 0 1 1-3.361 0v-4.21ZM5.89 3.361a1.68 1.68 0 1 1 1.681-1.68v1.68H5.89ZM5.89 4.209a1.68 1.68 0 1 1 0 3.361H1.68a1.68 1.68 0 1 1 0-3.361h4.21ZM12.639 5.89a1.68 1.68 0 1 1 1.68 1.681h-1.68V5.89ZM11.791 5.89a1.68 1.68 0 1 1-3.361 0V1.68a1.68 1.68 0 0 1 3.361 0v4.21ZM10.11 12.639a1.68 1.68 0 1 1-1.681 1.68v-1.68h1.682ZM10.11 11.791a1.68 1.68 0 1 1 0-3.361h4.21a1.68 1.68 0 1 1 0 3.361h-4.21Z" />
+                  </svg>
+                  Join us on Slack
+                </a>
+              </div>
+              <div>
+                <a
+                  href="https://fly.io/docs/elixir/getting-started/"
+                  class="group -mx-2 -my-0.5 inline-flex items-center gap-3 rounded-lg px-2 py-0.5 hover:bg-base-200 hover:text-base-content"
+                >
+                  <svg
+                    viewBox="0 0 20 20"
+                    aria-hidden="true"
+                    class="h-4 w-4 fill-base-content/40 group-hover:fill-base-content"
                   >
                     <path d="M1 12.5A4.5 4.5 0 005.5 17H15a4 4 0 001.866-7.539 3.504 3.504 0 00-4.504-4.272A4.5 4.5 0 004.06 8.235 4.502 4.502 0 001 12.5z" />
                   </svg>

--- a/lib/mix/tasks/phx_install.install.ex
+++ b/lib/mix/tasks/phx_install.install.ex
@@ -22,12 +22,17 @@ defmodule Mix.Tasks.PhxInstall.Install do
   - `--gettext` / `--no-gettext` - Include Gettext i18n (default: true)
   - `--dashboard` / `--no-dashboard` - Include LiveDashboard (default: true)
   - `--page` / `--no-page` - Include stock homepage (default: true)
+  - `--css` - CSS framework: "tailwind" (default) or "none"
+  - `--ui` - UI component library: "daisy" (default), "tailwind", or "none"
   - `--remove-after-install` / `--no-remove-after-install` - Remove `:phx_install` from deps after installation (default: false)
 
   ## Examples
 
       # Install with all defaults
       mix igniter.install phx_install
+
+      # Plain Tailwind CSS (no DaisyUI)
+      mix igniter.install phx_install --ui tailwind
 
       # API-only (no LiveView, no assets)
       mix igniter.install phx_install --no-live --no-assets

--- a/lib/mix/tasks/phx_install.install.ex
+++ b/lib/mix/tasks/phx_install.install.ex
@@ -47,23 +47,27 @@ defmodule Mix.Tasks.PhxInstall.Install do
       example: "mix igniter.install phx_install",
       schema: [
         assets: :boolean,
+        css: :string,
         dashboard: :boolean,
         ecto: :boolean,
         gettext: :boolean,
         live: :boolean,
         mailer: :boolean,
         page: :boolean,
-        remove_after_install: :boolean
+        remove_after_install: :boolean,
+        ui: :string
       ],
       defaults: [
         assets: true,
+        css: "tailwind",
         dashboard: true,
         ecto: true,
         gettext: true,
         live: true,
         mailer: true,
         page: true,
-        remove_after_install: false
+        remove_after_install: false,
+        ui: "daisy"
       ],
       composes: ["phx.install"]
     }

--- a/lib/phx_install.ex
+++ b/lib/phx_install.ex
@@ -37,4 +37,32 @@ defmodule PhxInstall do
     |> Base.encode64()
     |> binary_part(0, length)
   end
+
+  @doc """
+  Appends an `@import` line to `assets/css/app.css`, inserting it before
+  the trailing comment marker. No-op if the import already exists or
+  if `app.css` has not been created yet.
+  """
+  def append_css_import(igniter, import_line) do
+    path = "assets/css/app.css"
+    marker = "/* This file is for your main application CSS */"
+
+    case Rewrite.source(igniter.rewrite, path) do
+      {:ok, source} ->
+        content = Rewrite.Source.get(source, :content)
+
+        if String.contains?(content, import_line) do
+          igniter
+        else
+          updated_content =
+            String.replace(content, marker, "#{import_line}\n#{marker}")
+
+          updated_source = Rewrite.Source.update(source, :content, updated_content)
+          %{igniter | rewrite: Rewrite.update!(igniter.rewrite, updated_source)}
+        end
+
+      {:error, _} ->
+        igniter
+    end
+  end
 end

--- a/test/mix/tasks/phx/install/assets_test.exs
+++ b/test/mix/tasks/phx/install/assets_test.exs
@@ -11,11 +11,32 @@ defmodule Mix.Tasks.Phx.Install.AssetsTest do
       |> assert_creates("assets/js/app.js")
     end
 
-    test "creates app.css" do
-      test_project()
-      |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-      |> Igniter.compose_task("phx.install.assets")
-      |> assert_creates("assets/css/app.css")
+    test "creates app.css with import lines" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
+        |> Igniter.compose_task("phx.install.assets")
+        |> apply_igniter!()
+
+      source = Rewrite.source!(igniter.rewrite, "assets/css/app.css")
+      content = Rewrite.Source.get(source, :content)
+
+      assert content =~ ~s|@import "./phx-tailwind.css";|
+    end
+
+    test "creates phx-tailwind.css with tailwind foundation" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
+        |> Igniter.compose_task("phx.install.assets")
+        |> apply_igniter!()
+
+      source = Rewrite.source!(igniter.rewrite, "assets/css/phx-tailwind.css")
+      content = Rewrite.Source.get(source, :content)
+
+      assert content =~ ~s|@import "tailwindcss" source(none);|
+      assert content =~ ~s|@custom-variant phx-click-loading|
+      assert content =~ ~s|data-phx-session|
     end
 
     test "creates static files" do
@@ -111,7 +132,7 @@ defmodule Mix.Tasks.Phx.Install.AssetsTest do
 
       assert content =~ "my_app:"
 
-      source = Rewrite.source!(igniter.rewrite, "assets/css/app.css")
+      source = Rewrite.source!(igniter.rewrite, "assets/css/phx-tailwind.css")
       content = Rewrite.Source.get(source, :content)
 
       assert content =~ "my_app_web"
@@ -130,12 +151,12 @@ defmodule Mix.Tasks.Phx.Install.AssetsTest do
     end
   end
 
-  describe "phx.install.assets --no-tailwind" do
+  describe "phx.install.assets --css none" do
     test "skips tailwind configuration" do
       igniter =
         test_project()
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.assets", ["--no-tailwind"])
+        |> Igniter.compose_task("phx.install.assets", ["--css", "none"])
         |> apply_igniter!()
 
       source = Rewrite.source!(igniter.rewrite, "config/config.exs")
@@ -148,7 +169,7 @@ defmodule Mix.Tasks.Phx.Install.AssetsTest do
     test "still creates JS assets" do
       test_project()
       |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-      |> Igniter.compose_task("phx.install.assets", ["--no-tailwind"])
+      |> Igniter.compose_task("phx.install.assets", ["--css", "none"])
       |> assert_creates("assets/js/app.js")
     end
   end
@@ -218,6 +239,7 @@ defmodule Mix.Tasks.Phx.Install.AssetsTest do
         |> apply_igniter!()
 
       assert Map.has_key?(igniter.rewrite.sources, "assets/css/app.css")
+      assert Map.has_key?(igniter.rewrite.sources, "assets/css/phx-tailwind.css")
     end
   end
 end

--- a/test/mix/tasks/phx/install/components/daisy_test.exs
+++ b/test/mix/tasks/phx/install/components/daisy_test.exs
@@ -1,4 +1,4 @@
-defmodule Mix.Tasks.Phx.Install.ComponentsTest do
+defmodule Mix.Tasks.Phx.Install.Components.DaisyTest do
   use ExUnit.Case
 
   import Igniter.Test
@@ -10,16 +10,16 @@ defmodule Mix.Tasks.Phx.Install.ComponentsTest do
       "--live-signing-salt",
       "livesalt1",
       "--ui",
-      "tailwind"
+      "daisy"
     ])
     |> apply_igniter!()
   end
 
-  describe "phx.install.components" do
+  describe "phx.install.components --ui daisy" do
     test "adds header/1 to CoreComponents" do
       igniter =
         project_with_live()
-        |> Igniter.compose_task("phx.install.components", ["--ui", "tailwind"])
+        |> Igniter.compose_task("phx.install.components", ["--ui", "daisy"])
         |> apply_igniter!()
 
       source = Rewrite.source!(igniter.rewrite, "lib/test_web/components/core_components.ex")
@@ -30,65 +30,41 @@ defmodule Mix.Tasks.Phx.Install.ComponentsTest do
       assert content =~ "slot(:actions)"
     end
 
-    test "adds table/1 to CoreComponents" do
+    test "adds table/1 with gettext to CoreComponents" do
       igniter =
         project_with_live()
-        |> Igniter.compose_task("phx.install.components", ["--ui", "tailwind"])
+        |> Igniter.compose_task("phx.install.components", ["--ui", "daisy"])
         |> apply_igniter!()
 
       source = Rewrite.source!(igniter.rewrite, "lib/test_web/components/core_components.ex")
       content = Rewrite.Source.get(source, :content)
 
       assert content =~ "def table(assigns)"
-      assert content =~ "attr(:id, :string, required: true)"
-      assert content =~ "attr(:rows, :list, required: true)"
       assert content =~ "Phoenix.LiveView.LiveStream"
+      assert content =~ ~s|gettext("Actions")|
     end
 
     test "adds list/1 to CoreComponents" do
       igniter =
         project_with_live()
-        |> Igniter.compose_task("phx.install.components", ["--ui", "tailwind"])
+        |> Igniter.compose_task("phx.install.components", ["--ui", "daisy"])
         |> apply_igniter!()
 
       source = Rewrite.source!(igniter.rewrite, "lib/test_web/components/core_components.ex")
       content = Rewrite.Source.get(source, :content)
 
       assert content =~ "def list(assigns)"
-      assert content =~ "attr(:title, :string, required: true)"
     end
 
     test "is idempotent" do
       igniter =
         project_with_live()
-        |> Igniter.compose_task("phx.install.components", ["--ui", "tailwind"])
+        |> Igniter.compose_task("phx.install.components", ["--ui", "daisy"])
         |> apply_igniter!()
 
       igniter
-      |> Igniter.compose_task("phx.install.components", ["--ui", "tailwind"])
+      |> Igniter.compose_task("phx.install.components", ["--ui", "daisy"])
       |> assert_unchanged()
-    end
-
-    test "works with custom app name" do
-      igniter =
-        test_project(app_name: :my_app)
-        |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.live", [
-          "--live-signing-salt",
-          "livesalt1",
-          "--ui",
-          "tailwind"
-        ])
-        |> apply_igniter!()
-        |> Igniter.compose_task("phx.install.components", ["--ui", "tailwind"])
-        |> apply_igniter!()
-
-      source = Rewrite.source!(igniter.rewrite, "lib/my_app_web/components/core_components.ex")
-      content = Rewrite.Source.get(source, :content)
-
-      assert content =~ "def header(assigns)"
-      assert content =~ "def table(assigns)"
-      assert content =~ "def list(assigns)"
     end
   end
 end

--- a/test/mix/tasks/phx/install/components_test.exs
+++ b/test/mix/tasks/phx/install/components_test.exs
@@ -6,7 +6,12 @@ defmodule Mix.Tasks.Phx.Install.ComponentsTest do
   defp project_with_live do
     test_project()
     |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-    |> Igniter.compose_task("phx.install.live", ["--live-signing-salt", "livesalt1"])
+    |> Igniter.compose_task("phx.install.live", [
+      "--live-signing-salt",
+      "livesalt1",
+      "--ui",
+      "tailwind"
+    ])
     |> apply_igniter!()
   end
 
@@ -68,7 +73,12 @@ defmodule Mix.Tasks.Phx.Install.ComponentsTest do
       igniter =
         test_project(app_name: :my_app)
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.live", ["--live-signing-salt", "livesalt1"])
+        |> Igniter.compose_task("phx.install.live", [
+          "--live-signing-salt",
+          "livesalt1",
+          "--ui",
+          "tailwind"
+        ])
         |> apply_igniter!()
         |> Igniter.compose_task("phx.install.components")
         |> apply_igniter!()

--- a/test/mix/tasks/phx/install/heroicons_test.exs
+++ b/test/mix/tasks/phx/install/heroicons_test.exs
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Phx.Install.HeroiconsTest do
   defp project_with_assets do
     test_project()
     |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-    |> Igniter.compose_task("phx.install.html")
+    |> Igniter.compose_task("phx.install.html", ["--ui", "tailwind"])
     |> Igniter.compose_task("phx.install.assets")
     |> apply_igniter!()
   end
@@ -37,7 +37,19 @@ defmodule Mix.Tasks.Phx.Install.HeroiconsTest do
       assert content =~ "matchComponents"
     end
 
-    test "appends @plugin to app.css" do
+    test "creates phx-heroicons.css with plugin directive" do
+      igniter =
+        project_with_assets()
+        |> Igniter.compose_task("phx.install.heroicons")
+        |> apply_igniter!()
+
+      source = Rewrite.source!(igniter.rewrite, "assets/css/phx-heroicons.css")
+      content = Rewrite.Source.get(source, :content)
+
+      assert content =~ ~s|@plugin "../vendor/heroicons";|
+    end
+
+    test "appends @import to app.css" do
       igniter =
         project_with_assets()
         |> Igniter.compose_task("phx.install.heroicons")
@@ -46,7 +58,7 @@ defmodule Mix.Tasks.Phx.Install.HeroiconsTest do
       source = Rewrite.source!(igniter.rewrite, "assets/css/app.css")
       content = Rewrite.Source.get(source, :content)
 
-      assert content =~ ~s|@plugin "../vendor/heroicons";|
+      assert content =~ ~s|@import "./phx-heroicons.css";|
     end
 
     test "adds icon/1 to CoreComponents" do
@@ -77,7 +89,7 @@ defmodule Mix.Tasks.Phx.Install.HeroiconsTest do
       igniter =
         test_project(app_name: :my_app)
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.html")
+        |> Igniter.compose_task("phx.install.html", ["--ui", "tailwind"])
         |> Igniter.compose_task("phx.install.assets")
         |> apply_igniter!()
         |> Igniter.compose_task("phx.install.heroicons")

--- a/test/mix/tasks/phx/install/html/daisy_test.exs
+++ b/test/mix/tasks/phx/install/html/daisy_test.exs
@@ -1,0 +1,138 @@
+defmodule Mix.Tasks.Phx.Install.Html.DaisyTest do
+  use ExUnit.Case
+
+  import Igniter.Test
+
+  defp setup_project(opts \\ []) do
+    app_name = Keyword.get(opts, :app_name, :test)
+
+    test_project(app_name: app_name)
+    |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
+  end
+
+  describe "phx.install.html --ui daisy" do
+    test "creates CoreComponents with DaisyUI classes" do
+      igniter =
+        setup_project()
+        |> Igniter.compose_task("phx.install.html", ["--ui", "daisy"])
+        |> apply_igniter!()
+
+      source = Rewrite.source!(igniter.rewrite, "lib/test_web/components/core_components.ex")
+      content = Rewrite.Source.get(source, :content)
+
+      assert content =~ "use Phoenix.Component"
+      assert content =~ "use Gettext, backend: TestWeb.Gettext"
+      assert content =~ "toast toast-top toast-end"
+      assert content =~ "alert-info"
+      assert content =~ "btn-primary"
+      assert content =~ "fieldset"
+      assert content =~ "text-error"
+    end
+
+    test "creates Layouts with inline app/1 and flash_group/1" do
+      igniter =
+        setup_project()
+        |> Igniter.compose_task("phx.install.html", ["--ui", "daisy"])
+        |> apply_igniter!()
+
+      source = Rewrite.source!(igniter.rewrite, "lib/test_web/components/layouts.ex")
+      content = Rewrite.Source.get(source, :content)
+
+      assert content =~ "def app(assigns)"
+      assert content =~ "def flash_group(assigns)"
+      assert content =~ "def theme_toggle(assigns)"
+      assert content =~ "navbar"
+      assert content =~ "client-error"
+      assert content =~ "server-error"
+    end
+
+    test "creates root layout with theme-switching JS" do
+      igniter =
+        setup_project()
+        |> Igniter.compose_task("phx.install.html", ["--ui", "daisy"])
+        |> apply_igniter!()
+
+      source =
+        Rewrite.source!(igniter.rewrite, "lib/test_web/components/layouts/root.html.heex")
+
+      content = Rewrite.Source.get(source, :content)
+
+      assert content =~ "phx:theme"
+      assert content =~ "data-theme"
+      assert content =~ "setTheme"
+    end
+
+    test "creates logo SVG" do
+      setup_project()
+      |> Igniter.compose_task("phx.install.html", ["--ui", "daisy"])
+      |> assert_creates("priv/static/images/logo.svg")
+    end
+
+    test "creates phx-daisy.css with DaisyUI plugin config" do
+      igniter =
+        setup_project()
+        |> Igniter.compose_task("phx.install.assets")
+        |> Igniter.compose_task("phx.install.html", ["--ui", "daisy"])
+        |> apply_igniter!()
+
+      source = Rewrite.source!(igniter.rewrite, "assets/css/phx-daisy.css")
+      content = Rewrite.Source.get(source, :content)
+
+      assert content =~ ~s|@plugin "../vendor/daisyui"|
+      assert content =~ ~s|@plugin "../vendor/daisyui-theme"|
+      assert content =~ "name: \"dark\""
+      assert content =~ "name: \"light\""
+      assert content =~ "@custom-variant dark"
+    end
+
+    test "appends daisy CSS import to app.css" do
+      igniter =
+        setup_project()
+        |> Igniter.compose_task("phx.install.assets")
+        |> Igniter.compose_task("phx.install.html", ["--ui", "daisy"])
+        |> apply_igniter!()
+
+      source = Rewrite.source!(igniter.rewrite, "assets/css/app.css")
+      content = Rewrite.Source.get(source, :content)
+
+      assert content =~ ~s|@import "./phx-daisy.css";|
+    end
+
+    test "creates ErrorHTML module" do
+      setup_project()
+      |> Igniter.compose_task("phx.install.html", ["--ui", "daisy"])
+      |> assert_creates("lib/test_web/controllers/error_html.ex")
+    end
+
+    test "adds html function to web module" do
+      igniter =
+        setup_project()
+        |> Igniter.compose_task("phx.install.html", ["--ui", "daisy"])
+        |> apply_igniter!()
+
+      source = Rewrite.source!(igniter.rewrite, "lib/test_web.ex")
+      content = Rewrite.Source.get(source, :content)
+
+      assert content =~ "def html do"
+      assert content =~ "defp html_helpers do"
+    end
+
+    test "works with custom app name" do
+      igniter =
+        setup_project(app_name: :my_app)
+        |> Igniter.compose_task("phx.install.html", ["--ui", "daisy"])
+        |> apply_igniter!()
+
+      source = Rewrite.source!(igniter.rewrite, "lib/my_app_web/components/core_components.ex")
+      content = Rewrite.Source.get(source, :content)
+
+      assert content =~ "defmodule MyAppWeb.CoreComponents"
+      assert content =~ "use Gettext, backend: MyAppWeb.Gettext"
+
+      source = Rewrite.source!(igniter.rewrite, "lib/my_app_web/components/layouts.ex")
+      content = Rewrite.Source.get(source, :content)
+
+      assert content =~ "use MyAppWeb, :html"
+    end
+  end
+end

--- a/test/mix/tasks/phx/install/html_test.exs
+++ b/test/mix/tasks/phx/install/html_test.exs
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.Phx.Install.HtmlTest do
     test "creates CoreComponents module" do
       test_project()
       |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-      |> Igniter.compose_task("phx.install.html")
+      |> Igniter.compose_task("phx.install.html", ["--ui", "tailwind"])
       |> assert_creates("lib/test_web/components/core_components.ex")
     end
 
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.Phx.Install.HtmlTest do
       igniter =
         test_project()
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.html")
+        |> Igniter.compose_task("phx.install.html", ["--ui", "tailwind"])
         |> apply_igniter!()
 
       source = Rewrite.source!(igniter.rewrite, "lib/test_web/components/core_components.ex")
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.Phx.Install.HtmlTest do
     test "creates Layouts module" do
       test_project()
       |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-      |> Igniter.compose_task("phx.install.html")
+      |> Igniter.compose_task("phx.install.html", ["--ui", "tailwind"])
       |> assert_creates("lib/test_web/components/layouts.ex")
     end
 
@@ -41,7 +41,7 @@ defmodule Mix.Tasks.Phx.Install.HtmlTest do
       igniter =
         test_project()
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.html")
+        |> Igniter.compose_task("phx.install.html", ["--ui", "tailwind"])
         |> apply_igniter!()
 
       source = Rewrite.source!(igniter.rewrite, "lib/test_web/components/layouts.ex")
@@ -54,21 +54,21 @@ defmodule Mix.Tasks.Phx.Install.HtmlTest do
     test "creates root.html.heex layout" do
       test_project()
       |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-      |> Igniter.compose_task("phx.install.html")
+      |> Igniter.compose_task("phx.install.html", ["--ui", "tailwind"])
       |> assert_creates("lib/test_web/components/layouts/root.html.heex")
     end
 
     test "creates app.html.heex layout" do
       test_project()
       |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-      |> Igniter.compose_task("phx.install.html")
+      |> Igniter.compose_task("phx.install.html", ["--ui", "tailwind"])
       |> assert_creates("lib/test_web/components/layouts/app.html.heex")
     end
 
     test "creates ErrorHTML module" do
       test_project()
       |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-      |> Igniter.compose_task("phx.install.html")
+      |> Igniter.compose_task("phx.install.html", ["--ui", "tailwind"])
       |> assert_creates("lib/test_web/controllers/error_html.ex")
     end
 
@@ -76,7 +76,7 @@ defmodule Mix.Tasks.Phx.Install.HtmlTest do
       igniter =
         test_project()
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.html")
+        |> Igniter.compose_task("phx.install.html", ["--ui", "tailwind"])
         |> apply_igniter!()
 
       source = Rewrite.source!(igniter.rewrite, "lib/test_web/controllers/error_html.ex")
@@ -90,7 +90,7 @@ defmodule Mix.Tasks.Phx.Install.HtmlTest do
       igniter =
         test_project()
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.html")
+        |> Igniter.compose_task("phx.install.html", ["--ui", "tailwind"])
         |> apply_igniter!()
 
       source = Rewrite.source!(igniter.rewrite, "lib/test_web.ex")
@@ -104,7 +104,7 @@ defmodule Mix.Tasks.Phx.Install.HtmlTest do
       igniter =
         test_project()
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.html")
+        |> Igniter.compose_task("phx.install.html", ["--ui", "tailwind"])
         |> apply_igniter!()
 
       source = Rewrite.source!(igniter.rewrite, "lib/test_web.ex")
@@ -120,7 +120,7 @@ defmodule Mix.Tasks.Phx.Install.HtmlTest do
       igniter =
         test_project(app_name: :my_app)
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.html")
+        |> Igniter.compose_task("phx.install.html", ["--ui", "tailwind"])
         |> apply_igniter!()
 
       assert igniter.rewrite.sources["lib/my_app_web/components/core_components.ex"]
@@ -141,11 +141,11 @@ defmodule Mix.Tasks.Phx.Install.HtmlTest do
       igniter =
         test_project()
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.html")
+        |> Igniter.compose_task("phx.install.html", ["--ui", "tailwind"])
         |> apply_igniter!()
 
       igniter
-      |> Igniter.compose_task("phx.install.html")
+      |> Igniter.compose_task("phx.install.html", ["--ui", "tailwind"])
       |> assert_unchanged()
     end
   end

--- a/test/mix/tasks/phx/install/live_test.exs
+++ b/test/mix/tasks/phx/install/live_test.exs
@@ -21,7 +21,12 @@ defmodule Mix.Tasks.Phx.Install.LiveTest do
           "test_secret_key_base_12345678901234567890123456789012"
         ])
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.live", ["--live-signing-salt", "livesalt1"])
+        |> Igniter.compose_task("phx.install.live", [
+          "--live-signing-salt",
+          "livesalt1",
+          "--ui",
+          "tailwind"
+        ])
         |> apply_igniter!()
 
       source = Rewrite.source!(igniter.rewrite, "config/config.exs")
@@ -35,7 +40,12 @@ defmodule Mix.Tasks.Phx.Install.LiveTest do
       igniter =
         test_project()
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.live", ["--live-signing-salt", "livesalt1"])
+        |> Igniter.compose_task("phx.install.live", [
+          "--live-signing-salt",
+          "livesalt1",
+          "--ui",
+          "tailwind"
+        ])
         |> apply_igniter!()
 
       source = Rewrite.source!(igniter.rewrite, "lib/test_web/endpoint.ex")
@@ -50,7 +60,12 @@ defmodule Mix.Tasks.Phx.Install.LiveTest do
       igniter =
         test_project()
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.live", ["--live-signing-salt", "livesalt1"])
+        |> Igniter.compose_task("phx.install.live", [
+          "--live-signing-salt",
+          "livesalt1",
+          "--ui",
+          "tailwind"
+        ])
         |> apply_igniter!()
 
       source = Rewrite.source!(igniter.rewrite, "lib/test_web.ex")
@@ -64,7 +79,12 @@ defmodule Mix.Tasks.Phx.Install.LiveTest do
       igniter =
         test_project()
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.live", ["--live-signing-salt", "livesalt1"])
+        |> Igniter.compose_task("phx.install.live", [
+          "--live-signing-salt",
+          "livesalt1",
+          "--ui",
+          "tailwind"
+        ])
         |> apply_igniter!()
 
       source = Rewrite.source!(igniter.rewrite, "lib/test_web.ex")
@@ -78,7 +98,12 @@ defmodule Mix.Tasks.Phx.Install.LiveTest do
       igniter =
         test_project()
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.live", ["--live-signing-salt", "livesalt1"])
+        |> Igniter.compose_task("phx.install.live", [
+          "--live-signing-salt",
+          "livesalt1",
+          "--ui",
+          "tailwind"
+        ])
         |> apply_igniter!()
 
       source = Rewrite.source!(igniter.rewrite, "lib/test_web.ex")
@@ -91,7 +116,12 @@ defmodule Mix.Tasks.Phx.Install.LiveTest do
       igniter =
         test_project()
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.live", ["--live-signing-salt", "livesalt1"])
+        |> Igniter.compose_task("phx.install.live", [
+          "--live-signing-salt",
+          "livesalt1",
+          "--ui",
+          "tailwind"
+        ])
         |> apply_igniter!()
 
       source = Rewrite.source!(igniter.rewrite, "lib/test_web/components/core_components.ex")
@@ -108,11 +138,21 @@ defmodule Mix.Tasks.Phx.Install.LiveTest do
       igniter =
         test_project()
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.live", ["--live-signing-salt", "livesalt1"])
+        |> Igniter.compose_task("phx.install.live", [
+          "--live-signing-salt",
+          "livesalt1",
+          "--ui",
+          "tailwind"
+        ])
         |> apply_igniter!()
 
       igniter
-      |> Igniter.compose_task("phx.install.live", ["--live-signing-salt", "livesalt1"])
+      |> Igniter.compose_task("phx.install.live", [
+        "--live-signing-salt",
+        "livesalt1",
+        "--ui",
+        "tailwind"
+      ])
       |> assert_unchanged()
     end
 
@@ -120,7 +160,12 @@ defmodule Mix.Tasks.Phx.Install.LiveTest do
       igniter =
         test_project(app_name: :my_app)
         |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-        |> Igniter.compose_task("phx.install.live", ["--live-signing-salt", "livesalt1"])
+        |> Igniter.compose_task("phx.install.live", [
+          "--live-signing-salt",
+          "livesalt1",
+          "--ui",
+          "tailwind"
+        ])
         |> apply_igniter!()
 
       assert igniter.rewrite.sources["lib/my_app_web.ex"]

--- a/test/mix/tasks/phx/install/page_test.exs
+++ b/test/mix/tasks/phx/install/page_test.exs
@@ -15,14 +15,14 @@ defmodule Mix.Tasks.Phx.Install.PageTest do
   describe "phx.install.page" do
     test "creates PageController module" do
       setup_project()
-      |> Igniter.compose_task("phx.install.page")
+      |> Igniter.compose_task("phx.install.page", ["--ui", "tailwind"])
       |> assert_creates("lib/test_web/controllers/page_controller.ex")
     end
 
     test "PageController has home action" do
       igniter =
         setup_project()
-        |> Igniter.compose_task("phx.install.page")
+        |> Igniter.compose_task("phx.install.page", ["--ui", "tailwind"])
         |> apply_igniter!()
 
       source = Rewrite.source!(igniter.rewrite, "lib/test_web/controllers/page_controller.ex")
@@ -35,14 +35,14 @@ defmodule Mix.Tasks.Phx.Install.PageTest do
 
     test "creates PageHTML module" do
       setup_project()
-      |> Igniter.compose_task("phx.install.page")
+      |> Igniter.compose_task("phx.install.page", ["--ui", "tailwind"])
       |> assert_creates("lib/test_web/controllers/page_html.ex")
     end
 
     test "PageHTML embeds templates" do
       igniter =
         setup_project()
-        |> Igniter.compose_task("phx.install.page")
+        |> Igniter.compose_task("phx.install.page", ["--ui", "tailwind"])
         |> apply_igniter!()
 
       source = Rewrite.source!(igniter.rewrite, "lib/test_web/controllers/page_html.ex")
@@ -54,14 +54,14 @@ defmodule Mix.Tasks.Phx.Install.PageTest do
 
     test "creates home.html.heex template" do
       setup_project()
-      |> Igniter.compose_task("phx.install.page")
+      |> Igniter.compose_task("phx.install.page", ["--ui", "tailwind"])
       |> assert_creates("lib/test_web/controllers/page_html/home.html.heex")
     end
 
     test "home template has Phoenix content" do
       igniter =
         setup_project()
-        |> Igniter.compose_task("phx.install.page")
+        |> Igniter.compose_task("phx.install.page", ["--ui", "tailwind"])
         |> apply_igniter!()
 
       source =
@@ -77,7 +77,7 @@ defmodule Mix.Tasks.Phx.Install.PageTest do
     test "adds browser scope with root route to router" do
       igniter =
         setup_project()
-        |> Igniter.compose_task("phx.install.page")
+        |> Igniter.compose_task("phx.install.page", ["--ui", "tailwind"])
         |> apply_igniter!()
 
       source = Rewrite.source!(igniter.rewrite, "lib/test_web/router.ex")
@@ -91,7 +91,7 @@ defmodule Mix.Tasks.Phx.Install.PageTest do
     test "works with custom app name" do
       igniter =
         setup_project(app_name: :my_app)
-        |> Igniter.compose_task("phx.install.page")
+        |> Igniter.compose_task("phx.install.page", ["--ui", "tailwind"])
         |> apply_igniter!()
 
       assert igniter.rewrite.sources["lib/my_app_web/controllers/page_controller.ex"]
@@ -114,11 +114,11 @@ defmodule Mix.Tasks.Phx.Install.PageTest do
     test "is idempotent" do
       igniter =
         setup_project()
-        |> Igniter.compose_task("phx.install.page")
+        |> Igniter.compose_task("phx.install.page", ["--ui", "tailwind"])
         |> apply_igniter!()
 
       igniter
-      |> Igniter.compose_task("phx.install.page")
+      |> Igniter.compose_task("phx.install.page", ["--ui", "tailwind"])
       |> assert_unchanged()
     end
   end

--- a/test/mix/tasks/phx/install/page_test.exs
+++ b/test/mix/tasks/phx/install/page_test.exs
@@ -8,7 +8,7 @@ defmodule Mix.Tasks.Phx.Install.PageTest do
 
     test_project(app_name: app_name)
     |> Igniter.compose_task("phx.install.endpoint", ["--session-signing-salt", "sessionsalt"])
-    |> Igniter.compose_task("phx.install.html")
+    |> Igniter.compose_task("phx.install.html", ["--ui", "tailwind"])
     |> Igniter.compose_task("phx.install.router")
   end
 

--- a/test/mix/tasks/phx/install_test.exs
+++ b/test/mix/tasks/phx/install_test.exs
@@ -142,6 +142,35 @@ defmodule Mix.Tasks.Phx.InstallTest do
     end
   end
 
+  describe "phx.install --css and --ui options" do
+    test "defaults to css: tailwind and ui: daisy" do
+      info = Mix.Tasks.Phx.Install.info([], nil)
+
+      assert info.defaults[:css] == "tailwind"
+      assert info.defaults[:ui] == "daisy"
+    end
+
+    test "rejects --ui daisy with --css none" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("phx.install", [
+          "--ui",
+          "daisy",
+          "--css",
+          "none",
+          "--no-live",
+          "--no-assets",
+          "--no-gettext",
+          "--no-dashboard",
+          "--no-ecto",
+          "--no-mailer"
+        ])
+
+      assert igniter.issues != []
+      assert Enum.any?(igniter.issues, &String.contains?(&1, "daisy requires --css tailwind"))
+    end
+  end
+
   describe "phx_install.install" do
     test "--remove-after-install removes :phx_install from deps" do
       igniter =


### PR DESCRIPTION
## Summary

- Add `--css` and `--ui` options to the installer for pluggable CSS framework and UI component library selection
- DaisyUI is the new default (`--ui daisy`), matching Phoenix 1.8's `phx.new` output
- Plain Tailwind available via `--ui tailwind` for users who don't want DaisyUI
- Validates incompatible options (e.g. `--ui daisy --css none`)

## Architecture

Follows the same pluggable pattern used for JavaScript bundlers:

**CSS pipeline** — each task creates its own CSS file and appends `@import` to `app.css` (Tailwind v4 flattens imports before processing directives):
- `assets/css.ex` orchestrator selects CSS framework via `--css` flag
- `assets/css/tailwind.ex` creates `phx-tailwind.css` with Tailwind foundation
- `html/daisy.ex` creates `phx-daisy.css` with DaisyUI plugin/theme config
- `heroicons.ex` creates `phx-heroicons.css`

**HTML components** — `html.ex` refactored into orchestrator + variants:
- `html/daisy.ex` — DaisyUI components (toast flash, btn classes, fieldset inputs, theme toggle, dark/light theming, vendor JS downloaded from GitHub releases)
- `html/tailwind.ex` — plain Tailwind components (previous behaviour)

**Data display components** — `components.ex` refactored similarly:
- `components/daisy.ex` — gettext-aware table actions
- `components/tailwind.ex` — plain string table actions

**Page** — `page.ex` dispatches to variant-specific homepage templates

## Test plan

- [x] `mix test` — 174 tests pass (17 new, 0 failures)
- [ ] Verify `mix phx.install` produces DaisyUI output matching `.resources/example/`
- [ ] Verify `mix phx.install --ui tailwind` produces plain Tailwind output
- [ ] Verify `mix phx.install --ui daisy --css none` fails with clear error
- [ ] Manual test: generated DaisyUI app compiles and runs with theme toggle working
- [ ] Manual test: generated Tailwind-only app compiles and runs